### PR TITLE
feat: add /aimdl endpoint helpers to girder_io.py

### DIFF
--- a/ROADMAP_aimdl_refactor.md
+++ b/ROADMAP_aimdl_refactor.md
@@ -1,0 +1,206 @@
+# Refactoring Roadmap: Replace Directory Crawling with `/aimdl` Endpoint
+
+## Background
+
+The HELIX metadata extraction Dagster pipeline currently discovers PDV data files
+by crawling Girder folder trees — fetching up to 100,000 items to match a handful
+of PDV filenames from an experiment log spreadsheet. The Girder instance at
+`data.htmdec.org` now has an `/aimdl/datafiles` REST endpoint (implemented in the
+`girder-jsonforms` plugin, branch `igsn`) that performs an indexed MongoDB query
+filtered by `meta.data_type` and `meta.igsn`, returning only the relevant items
+without any directory traversal.
+
+## The `/aimdl` Endpoint (from `girder-jsonforms` plugin)
+
+**Source:** `Xarthisius/girder-jsonforms` on the `igsn` branch, file
+`girder_jsonforms/rest/aimdl.py`
+
+**Two routes:**
+
+| Route | Method | Description |
+|-------|--------|-------------|
+| `/aimdl/datatype` | GET | Returns distinct `meta.data_type` values across all items |
+| `/aimdl/datafiles` | GET | Returns Girder items filtered by `dataType`, paginated |
+
+**`/aimdl/datafiles` behavior:**
+- Requires `dataType` query parameter (string, required)
+- Supports `limit` (max 100, hard cap), `offset`, and `sort` (default: `lowerName`)
+- Queries MongoDB for items where:
+  - `meta.igsn` exists
+  - `meta.data_type` equals the requested type
+  - Item is in the AIMD-L collection (`665de536bcc722774ce53754`)
+- Returns standard Girder item objects with fields: `_id`, `name`, `meta.igsn`,
+  `meta.data_type`, `size`, `created`, `folderId`, `lowerName`
+- Requires user-level authentication (the existing API key auth works)
+
+**Available `meta.data_type` values:**
+- `pdv_trace` — raw PDV oscilloscope traces (what the pipeline matches against)
+- `pdv_alpss_result` — ALPSS processed result files
+- `pdv_alpss_output` — ALPSS output files
+- `xrd_raw`, `xrd_derived`, `xrd_metadata` — XRD data
+- `xrd_calibrant_raw`, `xrd_calibrant_derived` — XRD calibrant data
+- `xrf_raw` — XRF data
+
+## Current Pipeline Problems
+
+### Problem 1: Expensive inventory
+`pdv_inventory` fetches ALL items from PDV folder with `limit=100000`.
+This is the primary performance bottleneck.
+
+### Problem 2: Errors treated as data
+Invalid IGSNs become `igsn_issues`, unmatched PDV files become `pdv_issues`,
+write exceptions are swallowed into `write_errors`. Dagster always shows
+green unless an exception escapes the asset body. An operator looking at
+the Dagster UI sees a successful run even when 50% of rows failed to match.
+
+### Problem 3: No processing log
+There is no record of what was processed, when, or what the outcome was.
+The sensor cursor (a list of seen item IDs) lives in Dagster's storage
+and gets lost on reset. There's no way to look at a spreadsheet in Girder
+and know whether it was successfully processed.
+
+### Problem 4: No ALPSS completeness visibility
+The pipeline doesn't track whether ALPSS processing has completed for
+matched PDV traces. Operators have no visibility into the processing
+pipeline's coverage.
+
+## Target Architecture
+
+```
+Assets:
+  raw_experiment_log             ◄── unchanged
+       │
+  validated_rows                 ◄── unchanged
+       │  ✓ igsn_validity_rate check (WARN if <80%)
+       │
+  pdv_trace_inventory            ◄── NEW: /aimdl/datafiles?dataType=pdv_trace
+       │  ✓ zero_inventory check (ERROR if empty)
+       │
+  pdv_cross_references           ◄── UPDATED: IGSN consistency checking
+       │  ✓ pdv_match_rate check (WARN if <50%)
+       │  ✓ igsn_consistency check (ERROR on any mismatch)
+       │
+  enriched_pdv_metadata          ◄── unchanged
+       │  ✓ enrichment_success_rate check (WARN if <90%)
+       │  ✓ no_write_errors check (ERROR on any exception)
+       │
+  alpss_results_inventory        ◄── NEW: /aimdl/datafiles?dataType=pdv_alpss_result
+       │
+  quality_report                 ◄── UPDATED: ALPSS completeness, comprehensive
+       │
+  processing_manifest            ◄── NEW: writes meta.processing_status to Girder
+```
+
+## Critical Prerequisite
+
+The `/aimdl/datafiles` endpoint **requires `meta.igsn` to exist** on items.
+Items without `meta.igsn` will not appear in results. Until IGSN metadata is
+tagged on all PDV files, the endpoint will return an incomplete inventory.
+
+## Stages
+
+### Stage 1: Add `/aimdl` endpoint helpers to girder_io.py
+- Add `fetch_aimdl_datafiles()` and `fetch_all_aimdl_datafiles()` functions
+- Add `fetch_aimdl_datatypes()` function
+- Add `AIMDL_DATA_TYPES` constants
+- Add tests for the helpers (mocked Girder responses)
+- **No behavior changes to existing assets**
+- **Branch:** `feat/aimdl-helpers`
+- **Issue file:** `issues/01-add-aimdl-helpers.md`
+
+### Stage 2: Replace `pdv_inventory` with `pdv_trace_inventory`
+- Add new `pdv_trace_inventory` asset using `/aimdl/datafiles?dataType=pdv_trace`
+- Update `pdv_cross_references` to use `pdv_trace_inventory` upstream
+- Add IGSN consistency checking (cross-check spreadsheet IGSN vs item `meta.igsn`)
+- Update tests, remove `PDV_FOLDER_ID`, update `__init__.py`
+- **Branch:** `feat/replace-pdv-inventory`
+- **Issue file:** `issues/02-replace-pdv-inventory.md`
+
+### Stage 3: Add Dagster asset checks for error surfacing
+- Add `@asset_check` functions that produce colored pass/warn/fail in Dagster UI
+- Six checks covering IGSN validity, PDV matching, IGSN consistency,
+  enrichment success, write errors, and inventory emptiness
+- Register checks in `__init__.py` Definitions
+- Operators can now see at a glance whether a run had quality issues
+- **Branch:** `feat/asset-checks`
+- **Issue file:** `issues/05-asset-checks.md`
+
+### Stage 4: Add processing manifest (write-back to Girder)
+- New `processing_manifest` asset that writes `meta.processing_status`
+  to the source spreadsheet Girder item after processing completes
+- Records: timestamp, dagster_run_id, status, row counts, issue summary
+- Update sensor to check manifest before triggering reprocessing
+- Enables idempotency, audit trail, and cross-system visibility
+- **Branch:** `feat/processing-manifest`
+- **Issue file:** `issues/06-processing-manifest.md`
+
+### Stage 5: Add ALPSS results inventory for quality reporting
+- Add `alpss_results_inventory` asset fetching `pdv_alpss_result` items
+- Enhance `quality_report` with ALPSS completeness metrics
+- **Branch:** `feat/alpss-results-inventory`
+- **Issue file:** `issues/03-alpss-results-inventory.md`
+
+### Stage 6: Optimize the sensor
+- Replace recursive folder crawl with sorted recent-items query
+- Integrate with processing manifest for smarter reprocessing decisions
+- **Branch:** `feat/optimize-sensor`
+- **Issue file:** `issues/04-optimize-sensor.md`
+
+## Environment Variable Changes
+
+| Variable | Status | Description |
+|----------|--------|-------------|
+| `GIRDER_API_URL` | Keep | API URL for data.htmdec.org |
+| `GIRDER_API_KEY` | Keep | Authentication |
+| `HELIX_FOLDER_ID` | Keep (for sensor) | Folder to watch for new spreadsheets |
+| `PDV_FOLDER_ID` | Remove (Stage 2) | No longer needed — replaced by endpoint |
+| `PDV_TRACE_DATA_TYPE` | Add (Stage 1) | Default: `pdv_trace` |
+| `ALPSS_RESULT_DATA_TYPE` | Add (Stage 1) | Default: `pdv_alpss_result` |
+
+## Files Changed by Stage
+
+| File | S1 | S2 | S3 | S4 | S5 | S6 |
+|------|----|----|----|----|----|----|
+| `girder_io.py` | ✅ add | | | ✅ add | | ✅ rm |
+| `constants.py` | ✅ add | ✅ rm | | | | |
+| `assets.py` | | ✅ replace | | ✅ add | ✅ add | |
+| `checks.py` | | | ✅ new | | | |
+| `matching.py` | | ✅ update | | | | |
+| `sensors.py` | | | | ✅ update | | ✅ update |
+| `__init__.py` | | ✅ update | ✅ update | ✅ update | ✅ update | |
+| `tests/test_girder_io.py` | ✅ new | | | | | |
+| `tests/test_checks.py` | | | ✅ new | | | |
+| `tests/test_assets.py` | | ✅ update | | ✅ add | ✅ add | |
+| `tests/test_matching.py` | | ✅ update | | | | |
+| `CLAUDE.md` | | ✅ update | ✅ update | ✅ update | | ✅ update |
+
+## Design Decision: Asset Checks vs. Blocking
+
+The checks are designed in two tiers:
+
+**WARN checks** (yellow in UI, non-blocking):
+- `igsn_validity_rate` — Bad IGSNs may be correctable
+- `pdv_match_rate` — Low match rate may be expected during initial setup
+- `enrichment_success_rate` — Partial success is still useful
+
+**ERROR checks** (red in UI, optionally blocking):
+- `zero_inventory` — Empty inventory means the endpoint isn't returning data
+- `igsn_consistency` — IGSN mismatch is a data integrity problem
+- `no_write_errors` — Girder write failures need immediate attention
+
+ERROR checks can be set to `blocking=True` to prevent downstream assets
+from materializing when they fail. Start non-blocking, then tighten once
+the pipeline is stable.
+
+## Design Decision: Processing Manifest Location
+
+The manifest is written to Girder as `meta.processing_status` on the
+source spreadsheet item. This was chosen over alternatives:
+
+- **Dagster IO manager**: Would store in Dagster's own storage, invisible
+  from Girder. Loses the cross-system visibility benefit.
+- **Separate Girder item**: Would create a separate "receipt" file.
+  More complex, harder to discover.
+- **On the source spreadsheet item**: Natural place. Anyone browsing the
+  data portal can see if/when processing happened. The sensor can read
+  it directly.

--- a/claude_code_prompt_stage1_aimdl_helpers.md
+++ b/claude_code_prompt_stage1_aimdl_helpers.md
@@ -1,0 +1,296 @@
+# Claude Code Prompt — Stage 1: Add `/aimdl` endpoint helpers
+
+**Read CLAUDE.md first.** Then read `ROADMAP_aimdl_refactor.md` for full context.
+Then read `issues/01-add-aimdl-helpers.md`.
+
+## GitHub Issue
+
+```bash
+gh issue create \
+  --title "feat: add /aimdl endpoint helper functions to girder_io.py" \
+  --body-file issues/01-add-aimdl-helpers.md \
+  --label "enhancement"
+```
+
+Note the issue number returned.
+
+## Branch
+
+```bash
+git checkout refactor/asset-dag
+git pull
+git checkout -b feat/aimdl-helpers
+```
+
+## Context
+
+The Girder instance at `data.htmdec.org` has an `/aimdl` REST endpoint with two
+routes (see `ROADMAP_aimdl_refactor.md` for full API details):
+
+- `GET /aimdl/datatype` → list of distinct `meta.data_type` strings
+- `GET /aimdl/datafiles?dataType=...&limit=N&offset=N` → paginated Girder items
+
+The endpoint has a hard limit of 100 items per page. Items must have `meta.igsn`
+set to appear in results.
+
+Available `meta.data_type` values: `pdv_trace`, `pdv_alpss_result`,
+`pdv_alpss_output`, `xrd_raw`, `xrd_derived`, `xrd_metadata`,
+`xrd_calibrant_raw`, `xrd_calibrant_derived`, `xrf_raw`.
+
+## Changes
+
+### Step 1: Add data type constants to constants.py
+
+Add to `helix_dagster/constants.py`:
+
+```python
+# /aimdl endpoint data types
+# These correspond to meta.data_type values set on Girder items
+AIMDL_DATA_TYPES = {
+    "pdv_trace": "pdv_trace",
+    "pdv_alpss_result": "pdv_alpss_result",
+    "pdv_alpss_output": "pdv_alpss_output",
+    "xrd_raw": "xrd_raw",
+    "xrd_derived": "xrd_derived",
+    "xrd_metadata": "xrd_metadata",
+    "xrd_calibrant_raw": "xrd_calibrant_raw",
+    "xrd_calibrant_derived": "xrd_calibrant_derived",
+    "xrf_raw": "xrf_raw",
+}
+
+# Default data type for PDV trace matching (used by pdv_trace_inventory asset)
+PDV_TRACE_DATA_TYPE = os.environ.get("PDV_TRACE_DATA_TYPE", "pdv_trace")
+ALPSS_RESULT_DATA_TYPE = os.environ.get("ALPSS_RESULT_DATA_TYPE", "pdv_alpss_result")
+
+# Hard limit imposed by the /aimdl/datafiles endpoint
+AIMDL_PAGE_LIMIT = 100
+```
+
+Keep `PDV_FOLDER_ID` and `HELIX_FOLDER_ID` for now — they're still used by
+other code. They'll be removed in Stage 2.
+
+### Step 2: Add helper functions to girder_io.py
+
+Add to `helix_dagster/girder_io.py`:
+
+```python
+from helix_dagster.constants import AIMDL_PAGE_LIMIT
+
+
+def fetch_aimdl_datatypes(client):
+    """Fetch the list of available meta.data_type values from /aimdl/datatype.
+
+    Returns a list of strings, e.g. ["pdv_trace", "xrd_raw", ...].
+    """
+    return client.get("aimdl/datatype")
+
+
+def fetch_aimdl_datafiles(client, data_type, limit=100, offset=0):
+    """Fetch a single page of items from /aimdl/datafiles.
+
+    Parameters
+    ----------
+    client : GirderClient
+        Authenticated Girder client.
+    data_type : str
+        The meta.data_type value to filter by (e.g., "pdv_trace").
+    limit : int
+        Max items per page (capped at 100 by endpoint).
+    offset : int
+        Pagination offset.
+
+    Returns
+    -------
+    list[dict]
+        List of Girder item dicts with _id, name, meta.igsn, meta.data_type,
+        size, created, folderId, etc.
+    """
+    return client.get(
+        "aimdl/datafiles",
+        parameters={
+            "dataType": data_type,
+            "limit": min(limit, AIMDL_PAGE_LIMIT),
+            "offset": offset,
+        },
+    )
+
+
+def fetch_all_aimdl_datafiles(client, data_type):
+    """Paginate through all items of a given data type via /aimdl/datafiles.
+
+    The endpoint has a hard limit of 100 per page. This function fetches all
+    pages and returns the concatenated result.
+
+    Parameters
+    ----------
+    client : GirderClient
+        Authenticated Girder client.
+    data_type : str
+        The meta.data_type value to filter by.
+
+    Returns
+    -------
+    list[dict]
+        All matching Girder item dicts.
+    """
+    all_items = []
+    offset = 0
+    while True:
+        batch = fetch_aimdl_datafiles(client, data_type, offset=offset)
+        if not batch:
+            break
+        all_items.extend(batch)
+        if len(batch) < AIMDL_PAGE_LIMIT:
+            break
+        offset += AIMDL_PAGE_LIMIT
+    return all_items
+```
+
+Do NOT remove any existing functions. The existing `list_all_spreadsheet_items`,
+`download_and_read`, and `nan_to_none` functions are still used.
+
+### Step 3: Add tests
+
+Create `tests/test_girder_io.py`:
+
+```python
+"""Tests for the /aimdl endpoint helper functions."""
+
+from unittest.mock import MagicMock
+
+from helix_dagster.girder_io import (
+    fetch_aimdl_datatypes,
+    fetch_aimdl_datafiles,
+    fetch_all_aimdl_datafiles,
+)
+
+
+def _make_item(name, igsn, data_type, item_id=None):
+    """Helper to create a mock Girder item dict."""
+    return {
+        "_id": item_id or f"id_{name}",
+        "name": name,
+        "meta": {"igsn": igsn, "data_type": data_type},
+        "size": 1024,
+        "created": "2025-01-01T00:00:00Z",
+        "folderId": "folder123",
+        "lowerName": name.lower(),
+    }
+
+
+def test_fetch_datatypes():
+    client = MagicMock()
+    client.get.return_value = ["pdv_trace", "xrd_raw", "pdv_alpss_result"]
+    result = fetch_aimdl_datatypes(client)
+    client.get.assert_called_once_with("aimdl/datatype")
+    assert result == ["pdv_trace", "xrd_raw", "pdv_alpss_result"]
+
+
+def test_fetch_datafiles_single_page():
+    items = [_make_item(f"file{i}.tdms", "ABCDEF12345", "pdv_trace") for i in range(5)]
+    client = MagicMock()
+    client.get.return_value = items
+    result = fetch_aimdl_datafiles(client, "pdv_trace", limit=100, offset=0)
+    client.get.assert_called_once_with(
+        "aimdl/datafiles",
+        parameters={"dataType": "pdv_trace", "limit": 100, "offset": 0},
+    )
+    assert len(result) == 5
+
+
+def test_fetch_datafiles_respects_limit_cap():
+    """Verify that limit is capped at 100 even if caller requests more."""
+    client = MagicMock()
+    client.get.return_value = []
+    fetch_aimdl_datafiles(client, "pdv_trace", limit=500, offset=0)
+    call_params = client.get.call_args[1]["parameters"]
+    assert call_params["limit"] == 100
+
+
+def test_fetch_all_paginates():
+    """fetch_all should paginate until a short page is returned."""
+    page1 = [_make_item(f"f{i}", "IGSN1", "pdv_trace") for i in range(100)]
+    page2 = [_make_item(f"f{i}", "IGSN1", "pdv_trace") for i in range(100, 130)]
+
+    client = MagicMock()
+    client.get.side_effect = [page1, page2]
+    result = fetch_all_aimdl_datafiles(client, "pdv_trace")
+    assert len(result) == 130
+    assert client.get.call_count == 2
+
+
+def test_fetch_all_empty():
+    client = MagicMock()
+    client.get.return_value = []
+    result = fetch_all_aimdl_datafiles(client, "pdv_trace")
+    assert result == []
+
+
+def test_fetch_all_single_page():
+    items = [_make_item(f"f{i}", "IGSN1", "pdv_trace") for i in range(50)]
+    client = MagicMock()
+    client.get.return_value = items
+    result = fetch_all_aimdl_datafiles(client, "pdv_trace")
+    assert len(result) == 50
+    assert client.get.call_count == 1  # No second page needed
+```
+
+### Step 4: Verify
+
+```bash
+poetry run pytest tests/test_girder_io.py -v
+poetry run pytest tests/ -v  # ensure no regressions
+```
+
+### Step 5: Commit, push, create PR
+
+```bash
+git add -A
+git commit -m "feat: add /aimdl endpoint helper functions to girder_io.py
+
+Added fetch_aimdl_datatypes(), fetch_aimdl_datafiles(), and
+fetch_all_aimdl_datafiles() to girder_io.py for querying the indexed
+/aimdl/datafiles endpoint on the Girder data portal.
+
+Added AIMDL_DATA_TYPES constants and per-page limit to constants.py.
+Added unit tests with mocked Girder responses.
+
+No changes to existing asset behavior.
+
+Closes #ISSUE_NUMBER"
+git push -u origin feat/aimdl-helpers
+
+gh pr create \
+  --title "feat: add /aimdl endpoint helpers to girder_io.py" \
+  --body "## Summary
+
+Adds helper functions for the \`/aimdl/datafiles\` Girder endpoint, which
+performs indexed MongoDB queries by \`meta.data_type\` instead of crawling
+folder trees. This is Stage 1 of the refactoring described in
+\`ROADMAP_aimdl_refactor.md\`.
+
+## Changes
+
+- \`girder_io.py\`: Added \`fetch_aimdl_datatypes()\`, \`fetch_aimdl_datafiles()\`,
+  and \`fetch_all_aimdl_datafiles()\` with pagination support
+- \`constants.py\`: Added \`AIMDL_DATA_TYPES\`, \`PDV_TRACE_DATA_TYPE\`,
+  \`ALPSS_RESULT_DATA_TYPE\`, \`AIMDL_PAGE_LIMIT\`
+- \`tests/test_girder_io.py\`: 6 unit tests with mocked Girder responses
+
+No behavior changes to existing assets.
+
+Closes #ISSUE_NUMBER" \
+  --base refactor/asset-dag
+```
+
+## Verification Checklist
+
+- [ ] GitHub issue created
+- [ ] `fetch_aimdl_datatypes` function added
+- [ ] `fetch_aimdl_datafiles` function added with limit cap
+- [ ] `fetch_all_aimdl_datafiles` function paginates correctly
+- [ ] Constants added to `constants.py`
+- [ ] All 6 new tests pass
+- [ ] Existing tests still pass (no regressions)
+- [ ] No changes to existing asset behavior
+- [ ] PR created against `refactor/asset-dag` branch

--- a/claude_code_prompt_stage2_replace_inventory.md
+++ b/claude_code_prompt_stage2_replace_inventory.md
@@ -1,0 +1,314 @@
+# Claude Code Prompt — Stage 2: Replace `pdv_inventory` with `/aimdl` endpoint
+
+**Read CLAUDE.md first.** Then read `ROADMAP_aimdl_refactor.md` for full context.
+Then read `issues/02-replace-pdv-inventory.md`.
+
+**Prerequisite:** Stage 1 must be merged. The `fetch_all_aimdl_datafiles` function
+must exist in `girder_io.py` and `PDV_TRACE_DATA_TYPE` must exist in `constants.py`.
+
+## GitHub Issue
+
+```bash
+gh issue create \
+  --title "feat: replace pdv_inventory with /aimdl/datafiles endpoint" \
+  --body-file issues/02-replace-pdv-inventory.md \
+  --label "enhancement"
+```
+
+## Branch
+
+```bash
+git checkout refactor/asset-dag
+git pull
+git checkout -b feat/replace-pdv-inventory
+```
+
+## Overview
+
+Replace the `pdv_inventory` asset (which fetches 100,000+ items from a folder) with
+`pdv_trace_inventory` (which queries the indexed `/aimdl/datafiles?dataType=pdv_trace`
+endpoint). Update all downstream dependencies and tests.
+
+## Changes
+
+### Step 1: Replace `pdv_inventory` asset in assets.py
+
+In `helix_dagster/assets.py`:
+
+1. Remove the `pdv_inventory` asset function entirely.
+
+2. Add the import:
+   ```python
+   from helix_dagster.girder_io import fetch_all_aimdl_datafiles
+   from helix_dagster.constants import PDV_TRACE_DATA_TYPE
+   ```
+
+3. Add the new asset:
+   ```python
+   @asset
+   def pdv_trace_inventory(
+       context: AssetExecutionContext,
+       girder: GirderConnection,
+   ) -> list:
+       """Fetch PDV trace items via the /aimdl/datafiles endpoint.
+
+       Uses an indexed MongoDB query filtered by meta.data_type='pdv_trace'
+       instead of crawling the PDV folder tree. Items must have meta.igsn
+       set to appear in results.
+       """
+       items = fetch_all_aimdl_datafiles(girder, PDV_TRACE_DATA_TYPE)
+
+       # Extract unique IGSNs from the inventory
+       igsns = set()
+       for item in items:
+           igsn = item.get("meta", {}).get("igsn")
+           if igsn:
+               igsns.add(igsn)
+
+       context.add_output_metadata({
+           "item_count": MetadataValue.int(len(items)),
+           "unique_igsns": MetadataValue.int(len(igsns)),
+           "data_type": MetadataValue.text(PDV_TRACE_DATA_TYPE),
+       })
+
+       if len(items) == 0:
+           context.log.warning(
+               "pdv_trace_inventory returned 0 items. This may indicate that "
+               "meta.igsn has not been tagged on PDV files yet."
+           )
+
+       return items
+   ```
+
+4. Remove the `PDV_FOLDER_ID` import from the top of assets.py (it was used
+   by the old `pdv_inventory`). Keep other imports from constants.
+
+### Step 2: Update `pdv_cross_references` upstream dependency
+
+In `helix_dagster/assets.py`, change the `pdv_cross_references` asset:
+
+**Before:**
+```python
+@asset
+def pdv_cross_references(
+    context: AssetExecutionContext,
+    validated_rows: dict,
+    pdv_inventory: list,
+) -> dict:
+```
+
+**After:**
+```python
+@asset
+def pdv_cross_references(
+    context: AssetExecutionContext,
+    validated_rows: dict,
+    pdv_trace_inventory: list,
+) -> dict:
+```
+
+Update the body to use `pdv_trace_inventory` instead of `pdv_inventory`:
+
+**Before:**
+```python
+    pdv_item, issue = match_pdv_file(pdv_inventory, pdv_filename)
+```
+
+**After:**
+```python
+    pdv_item, issue = match_pdv_file(pdv_trace_inventory, pdv_filename)
+```
+
+### Step 3: Add IGSN consistency checking to `pdv_cross_references`
+
+After a successful match, cross-check the IGSN from the spreadsheet row against
+the `meta.igsn` on the matched Girder item. This catches data provenance errors
+where a PDV file is tagged with a different IGSN than the experiment log expects.
+
+Add after the match succeeds:
+```python
+    if pdv_item is not None:
+        matches[idx] = pdv_item
+        # Cross-check IGSN consistency
+        row_igsn = row.get("valid_igsn")
+        item_igsn = pdv_item.get("meta", {}).get("igsn")
+        if row_igsn and item_igsn and row_igsn != item_igsn:
+            pdv_issues.append({
+                "pdv_filename": pdv_filename,
+                "type": "igsn_mismatch",
+                "row": idx,
+                "spreadsheet_igsn": row_igsn,
+                "item_igsn": item_igsn,
+            })
+```
+
+Add the mismatch count to output metadata:
+```python
+    mismatch_count = sum(1 for i in pdv_issues if i["type"] == "igsn_mismatch")
+
+    context.add_output_metadata({
+        "matched_count": MetadataValue.int(matched_count),
+        "not_found_count": MetadataValue.int(not_found_count),
+        "ambiguous_count": MetadataValue.int(ambiguous_count),
+        "igsn_mismatch_count": MetadataValue.int(mismatch_count),
+    })
+```
+
+### Step 4: Remove `PDV_FOLDER_ID` from constants.py
+
+In `helix_dagster/constants.py`, remove the line:
+```python
+PDV_FOLDER_ID = os.environ.get("PDV_FOLDER_ID")
+```
+
+It is no longer used by any code.
+
+### Step 5: Update `__init__.py` Definitions
+
+In `helix_dagster/__init__.py`:
+
+1. Change the import:
+   **Before:** `pdv_inventory,`
+   **After:** `pdv_trace_inventory,`
+
+2. Update the assets list:
+   **Before:** `pdv_inventory,`
+   **After:** `pdv_trace_inventory,`
+
+### Step 6: Update tests
+
+**`tests/test_assets.py`:**
+
+Update `test_pdv_cross_references_pure`:
+- Change the parameter name from `pdv_inventory=pdv_items` to
+  `pdv_trace_inventory=pdv_items`
+- Add `meta.igsn` to mock items to test IGSN consistency:
+  ```python
+  pdv_items = [
+      {"name": "shot001_ch1.tdms", "_id": "a1", "meta": {"igsn": "ABCDEF12345", "data_type": "pdv_trace"}},
+      {"name": "shot002_ch1.tdms", "_id": "b1", "meta": {"igsn": "ABCDEF12346", "data_type": "pdv_trace"}},
+  ]
+  ```
+
+Update `test_asset_dag_loads`:
+- Change `"pdv_inventory"` to `"pdv_trace_inventory"` in the expected set
+
+Add a new test `test_igsn_mismatch_detection`:
+```python
+def test_igsn_mismatch_detection():
+    """Verify that IGSN mismatches between spreadsheet and Girder item are flagged."""
+    df = pd.DataFrame([
+        {"Sample_IGSN": "ABCDEF12345", "PDV_FileName": "shot001",
+         "valid_igsn": "ABCDEF12345"},
+    ])
+    pdv_items = [
+        {"name": "shot001_ch1.tdms", "_id": "a1",
+         "meta": {"igsn": "XXXXXX99999", "data_type": "pdv_trace"}},
+    ]
+    validated = {"dataframe": df, "igsn_issues": []}
+    ctx = build_asset_context()
+    result = pdv_cross_references_fn(
+        context=ctx,
+        validated_rows=validated,
+        pdv_trace_inventory=pdv_items,
+    )
+    issues = result["pdv_issues"]
+    mismatch_issues = [i for i in issues if i["type"] == "igsn_mismatch"]
+    assert len(mismatch_issues) == 1
+    assert mismatch_issues[0]["spreadsheet_igsn"] == "ABCDEF12345"
+    assert mismatch_issues[0]["item_igsn"] == "XXXXXX99999"
+```
+
+**`tests/test_matching.py`:**
+
+The existing tests use items without `meta` field, which is fine — the matching
+function only looks at `name`. No changes needed here unless the match function
+changes.
+
+### Step 7: Update CLAUDE.md
+
+Update the Workflow section to describe the new inventory approach:
+```
+## Workflow
+1. Sensor polls a Girder folder for new experiment log spreadsheets (CSV/XLSX)
+2. Pipeline downloads, parses, validates IGSNs
+3. PDV trace inventory fetched via /aimdl/datafiles?dataType=pdv_trace
+   (indexed MongoDB query, no directory crawling)
+4. Cross-references PDV filenames and checks IGSN consistency
+5. Writes enriched metadata to matched Girder items
+6. Quality issues reported as structured metadata on the Dagster run
+```
+
+Update the Environment variables section to remove `PDV_FOLDER_ID` and add
+`PDV_TRACE_DATA_TYPE`.
+
+### Step 8: Verify
+
+```bash
+poetry run pytest tests/ -v
+```
+
+All tests should pass, including the new IGSN mismatch test.
+
+### Step 9: Commit, push, create PR
+
+```bash
+git add -A
+git commit -m "feat: replace pdv_inventory with /aimdl/datafiles endpoint
+
+Replaced the pdv_inventory asset (which fetched 100,000+ items from the PDV
+folder) with pdv_trace_inventory (which queries the indexed /aimdl/datafiles
+endpoint for items with meta.data_type=pdv_trace).
+
+Added IGSN consistency checking: the pipeline now cross-checks the IGSN from
+the experiment log spreadsheet against meta.igsn on matched Girder items,
+flagging mismatches as a new quality issue type.
+
+Removed PDV_FOLDER_ID environment variable dependency.
+
+Closes #ISSUE_NUMBER"
+git push -u origin feat/replace-pdv-inventory
+
+gh pr create \
+  --title "feat: replace pdv_inventory with /aimdl/datafiles endpoint" \
+  --body "## Summary
+
+Replaces the \`pdv_inventory\` asset with \`pdv_trace_inventory\`, switching from
+a 100,000-item folder crawl to an indexed MongoDB query via the \`/aimdl/datafiles\`
+endpoint. Stage 2 of the refactoring in \`ROADMAP_aimdl_refactor.md\`.
+
+## Changes
+
+- **assets.py**: Replaced \`pdv_inventory\` with \`pdv_trace_inventory\` using
+  \`fetch_all_aimdl_datafiles()\`. Updated \`pdv_cross_references\` dependency.
+  Added IGSN consistency checking.
+- **constants.py**: Removed \`PDV_FOLDER_ID\`
+- **__init__.py**: Updated Definitions asset list
+- **tests**: Updated all references, added IGSN mismatch test
+- **CLAUDE.md**: Updated workflow and env var documentation
+
+## Migration Note
+
+The \`/aimdl/datafiles\` endpoint requires \`meta.igsn\` to exist on items.
+Until IGSN tagging is complete, some PDV files may not appear in the inventory.
+The asset logs a warning if the inventory is empty.
+
+Closes #ISSUE_NUMBER" \
+  --base refactor/asset-dag
+```
+
+## Verification Checklist
+
+- [ ] GitHub issue created
+- [ ] `pdv_inventory` asset removed from assets.py
+- [ ] `pdv_trace_inventory` asset added using `/aimdl/datafiles`
+- [ ] `pdv_cross_references` depends on `pdv_trace_inventory`
+- [ ] IGSN consistency checking added
+- [ ] `PDV_FOLDER_ID` removed from constants.py
+- [ ] `__init__.py` Definitions updated
+- [ ] `test_pdv_cross_references_pure` updated with new param name
+- [ ] `test_asset_dag_loads` updated with new asset name
+- [ ] `test_igsn_mismatch_detection` added and passing
+- [ ] CLAUDE.md updated
+- [ ] All tests pass
+- [ ] PR created against `refactor/asset-dag`

--- a/claude_code_prompt_stage3_asset_checks.md
+++ b/claude_code_prompt_stage3_asset_checks.md
@@ -1,0 +1,505 @@
+# Claude Code Prompt — Stage 3: Add Dagster asset checks for error surfacing
+
+**Read CLAUDE.md first.** Then read `ROADMAP_aimdl_refactor.md` for full context.
+Then read `issues/05-asset-checks.md`.
+
+**Prerequisite:** Stages 1 and 2 must be merged. The assets `pdv_trace_inventory`,
+`validated_rows`, `pdv_cross_references`, and `enriched_pdv_metadata` must exist.
+
+## GitHub Issue
+
+```bash
+gh issue create \
+  --title "feat: add Dagster asset checks for data quality surfacing" \
+  --body-file issues/05-asset-checks.md \
+  --label "enhancement"
+```
+
+## Branch
+
+```bash
+git checkout refactor/asset-dag
+git pull
+git checkout -b feat/asset-checks
+```
+
+## Overview
+
+The pipeline currently treats all data quality issues as data — invalid IGSNs
+become list entries, unmatched PDV files become dict entries, write exceptions
+are caught. Dagster always shows runs as "Success."
+
+Dagster's `@asset_check` mechanism evaluates data quality after each asset
+materializes and displays colored pass/warn/fail indicators in the UI. This
+stage adds checks for each critical asset without changing pipeline flow.
+
+## Changes
+
+### Step 1: Create `helix_dagster/checks.py`
+
+Create a new file `helix_dagster/checks.py` with all asset check functions:
+
+```python
+"""Dagster asset checks for data quality surfacing.
+
+These checks evaluate the output of each critical asset and produce
+pass/warn/fail indicators visible in the Dagster UI. They do NOT block
+pipeline execution — they are advisory.
+"""
+
+from dagster import (
+    AssetCheckResult,
+    AssetCheckSeverity,
+    asset_check,
+)
+
+
+@asset_check(asset="pdv_trace_inventory")
+def zero_inventory(context, pdv_trace_inventory):
+    """ERROR if the PDV trace inventory returned zero items.
+
+    This typically means meta.igsn has not been tagged on PDV files yet,
+    so the /aimdl/datafiles endpoint returns nothing.
+    """
+    count = len(pdv_trace_inventory)
+    passed = count > 0
+    return AssetCheckResult(
+        passed=passed,
+        severity=AssetCheckSeverity.ERROR,
+        metadata={"item_count": count},
+        description=(
+            f"Inventory contains {count} items."
+            if passed
+            else "Inventory is EMPTY. Check that meta.igsn is tagged on PDV files."
+        ),
+    )
+
+
+@asset_check(asset="validated_rows")
+def igsn_validity_rate(context, validated_rows):
+    """WARN if fewer than 80% of rows have valid IGSNs."""
+    df = validated_rows["dataframe"]
+    total = len(df)
+    if total == 0:
+        return AssetCheckResult(
+            passed=True,
+            severity=AssetCheckSeverity.WARN,
+            metadata={"total_rows": 0, "validity_rate": 0.0},
+            description="No rows to validate.",
+        )
+    valid_count = df["valid_igsn"].notna().sum()
+    rate = valid_count / total
+    passed = rate >= 0.8
+    return AssetCheckResult(
+        passed=passed,
+        severity=AssetCheckSeverity.WARN,
+        metadata={
+            "total_rows": total,
+            "valid_count": int(valid_count),
+            "validity_rate": round(float(rate), 3),
+        },
+        description=f"IGSN validity rate: {rate:.1%} ({valid_count}/{total})",
+    )
+
+
+@asset_check(asset="pdv_cross_references")
+def pdv_match_rate(context, pdv_cross_references, validated_rows):
+    """WARN if fewer than 50% of rows with PDV filenames were matched."""
+    df = validated_rows["dataframe"]
+    # Count rows that have a non-empty, non-NaN PDV filename
+    import math
+    rows_with_pdv = sum(
+        1
+        for _, row in df.iterrows()
+        if row.get("PDV_FileName") is not None
+        and not (isinstance(row.get("PDV_FileName"), float) and math.isnan(row.get("PDV_FileName")))
+        and str(row.get("PDV_FileName")).strip() != ""
+    )
+    matched_count = len(pdv_cross_references["matches"])
+    rate = matched_count / rows_with_pdv if rows_with_pdv > 0 else 0.0
+    passed = rate >= 0.5
+    return AssetCheckResult(
+        passed=passed,
+        severity=AssetCheckSeverity.WARN,
+        metadata={
+            "rows_with_pdv_filename": rows_with_pdv,
+            "matched_count": matched_count,
+            "match_rate": round(rate, 3),
+        },
+        description=f"PDV match rate: {rate:.1%} ({matched_count}/{rows_with_pdv})",
+    )
+
+
+@asset_check(asset="pdv_cross_references")
+def igsn_consistency(context, pdv_cross_references):
+    """ERROR if any matched PDV item has a different IGSN than the spreadsheet row."""
+    issues = pdv_cross_references["pdv_issues"]
+    mismatches = [i for i in issues if i.get("type") == "igsn_mismatch"]
+    passed = len(mismatches) == 0
+    metadata = {"mismatch_count": len(mismatches)}
+    if mismatches:
+        # Include first few mismatches for quick diagnosis
+        examples = mismatches[:3]
+        metadata["examples"] = str(examples)
+    return AssetCheckResult(
+        passed=passed,
+        severity=AssetCheckSeverity.ERROR,
+        metadata=metadata,
+        description=(
+            "No IGSN mismatches."
+            if passed
+            else f"{len(mismatches)} IGSN mismatch(es) between spreadsheet and Girder items."
+        ),
+    )
+
+
+@asset_check(asset="enriched_pdv_metadata")
+def enrichment_success_rate(context, enriched_pdv_metadata, pdv_cross_references):
+    """WARN if fewer than 90% of matched items were successfully enriched."""
+    matched_count = len(pdv_cross_references["matches"])
+    written_count = enriched_pdv_metadata["written_count"]
+    rate = written_count / matched_count if matched_count > 0 else 0.0
+    error_count = len(enriched_pdv_metadata["write_errors"])
+    passed = rate >= 0.9
+    return AssetCheckResult(
+        passed=passed,
+        severity=AssetCheckSeverity.WARN,
+        metadata={
+            "matched_count": matched_count,
+            "written_count": written_count,
+            "error_count": error_count,
+            "success_rate": round(rate, 3),
+        },
+        description=f"Enrichment success rate: {rate:.1%} ({written_count}/{matched_count})",
+    )
+
+
+@asset_check(asset="enriched_pdv_metadata")
+def coord_transform_check(context, enriched_pdv_metadata):
+    """WARN if any coordinate transformations failed."""
+    # The enriched_pdv_metadata asset currently doesn't expose coord_failures
+    # in its return dict, only as output metadata. We check write_errors as a proxy.
+    # TODO: expose coord_failures in the return dict in a future refactor.
+    errors = enriched_pdv_metadata["write_errors"]
+    passed = len(errors) == 0
+    return AssetCheckResult(
+        passed=passed,
+        severity=AssetCheckSeverity.WARN,
+        metadata={"write_error_count": len(errors)},
+        description=(
+            "No write errors."
+            if passed
+            else f"{len(errors)} metadata write error(s)."
+        ),
+    )
+```
+
+**Important:** The `pdv_match_rate` check needs `validated_rows` as an additional
+input to count how many rows had PDV filenames. Dagster allows asset checks to
+accept additional asset dependencies.
+
+### Step 2: Expose `coord_failures` in `enriched_pdv_metadata` return dict
+
+In `helix_dagster/assets.py`, update the `enriched_pdv_metadata` asset's return
+statement to include `coord_failures`:
+
+**Before:**
+```python
+    return {"written_count": written_count, "write_errors": write_errors}
+```
+
+**After:**
+```python
+    return {
+        "written_count": written_count,
+        "write_errors": write_errors,
+        "coord_failures": coord_failures,
+    }
+```
+
+Then update the `coord_transform_check` in `checks.py` to use this:
+
+```python
+@asset_check(asset="enriched_pdv_metadata")
+def coord_transform_check(context, enriched_pdv_metadata):
+    """WARN if any coordinate transformations failed."""
+    failures = enriched_pdv_metadata.get("coord_failures", 0)
+    passed = failures == 0
+    return AssetCheckResult(
+        passed=passed,
+        severity=AssetCheckSeverity.WARN,
+        metadata={"coord_failures": failures},
+        description=(
+            "All coordinate transforms succeeded."
+            if passed
+            else f"{failures} coordinate transform failure(s). Check COORD_TRANSFORMS_YAML."
+        ),
+    )
+```
+
+### Step 3: Register checks in `__init__.py`
+
+In `helix_dagster/__init__.py`, import and register all checks:
+
+```python
+from helix_dagster.checks import (
+    coord_transform_check,
+    enrichment_success_rate,
+    igsn_consistency,
+    igsn_validity_rate,
+    pdv_match_rate,
+    zero_inventory,
+)
+
+defs = Definitions(
+    assets=[
+        raw_experiment_log,
+        pdv_trace_inventory,
+        validated_rows,
+        pdv_cross_references,
+        enriched_pdv_metadata,
+        quality_report,
+    ],
+    asset_checks=[
+        zero_inventory,
+        igsn_validity_rate,
+        pdv_match_rate,
+        igsn_consistency,
+        enrichment_success_rate,
+        coord_transform_check,
+    ],
+    jobs=[process_helix_assets_job],
+    sensors=[helix_folder_sensor],
+    resources={...},  # unchanged
+)
+```
+
+### Step 4: Add tests
+
+Create `tests/test_checks.py`:
+
+```python
+"""Tests for Dagster asset checks."""
+
+import pandas as pd
+from dagster import build_asset_context
+
+from helix_dagster.checks import (
+    coord_transform_check,
+    enrichment_success_rate,
+    igsn_consistency,
+    igsn_validity_rate,
+    pdv_match_rate,
+    zero_inventory,
+)
+
+
+def test_zero_inventory_fails_on_empty():
+    ctx = build_asset_context()
+    result = zero_inventory(ctx, pdv_trace_inventory=[])
+    assert not result.passed
+    assert result.severity.value == "ERROR"
+
+
+def test_zero_inventory_passes_with_items():
+    ctx = build_asset_context()
+    result = zero_inventory(ctx, pdv_trace_inventory=[{"_id": "a"}])
+    assert result.passed
+
+
+def test_igsn_validity_rate_passes_above_threshold():
+    ctx = build_asset_context()
+    validated = {
+        "dataframe": pd.DataFrame({"valid_igsn": ["A", "B", "C", "D", None]}),
+        "igsn_issues": [],
+    }
+    result = igsn_validity_rate(ctx, validated_rows=validated)
+    assert result.passed  # 4/5 = 80%
+
+
+def test_igsn_validity_rate_warns_below_threshold():
+    ctx = build_asset_context()
+    validated = {
+        "dataframe": pd.DataFrame({"valid_igsn": ["A", None, None, None, None]}),
+        "igsn_issues": [],
+    }
+    result = igsn_validity_rate(ctx, validated_rows=validated)
+    assert not result.passed  # 1/5 = 20%
+    assert result.severity.value == "WARN"
+
+
+def test_pdv_match_rate_passes():
+    ctx = build_asset_context()
+    validated = {
+        "dataframe": pd.DataFrame({"PDV_FileName": ["shot1", "shot2"]}),
+        "igsn_issues": [],
+    }
+    xrefs = {"matches": {0: {}, 1: {}}, "pdv_issues": []}
+    result = pdv_match_rate(ctx, pdv_cross_references=xrefs, validated_rows=validated)
+    assert result.passed  # 2/2 = 100%
+
+
+def test_pdv_match_rate_warns():
+    ctx = build_asset_context()
+    validated = {
+        "dataframe": pd.DataFrame({"PDV_FileName": ["shot1", "shot2", "shot3", "shot4"]}),
+        "igsn_issues": [],
+    }
+    xrefs = {"matches": {0: {}}, "pdv_issues": []}
+    result = pdv_match_rate(ctx, pdv_cross_references=xrefs, validated_rows=validated)
+    assert not result.passed  # 1/4 = 25%
+
+
+def test_igsn_consistency_passes():
+    ctx = build_asset_context()
+    xrefs = {"matches": {}, "pdv_issues": []}
+    result = igsn_consistency(ctx, pdv_cross_references=xrefs)
+    assert result.passed
+
+
+def test_igsn_consistency_errors_on_mismatch():
+    ctx = build_asset_context()
+    xrefs = {
+        "matches": {},
+        "pdv_issues": [
+            {"type": "igsn_mismatch", "spreadsheet_igsn": "A", "item_igsn": "B"},
+        ],
+    }
+    result = igsn_consistency(ctx, pdv_cross_references=xrefs)
+    assert not result.passed
+    assert result.severity.value == "ERROR"
+
+
+def test_enrichment_success_rate_passes():
+    ctx = build_asset_context()
+    enriched = {"written_count": 9, "write_errors": [], "coord_failures": 0}
+    xrefs = {"matches": {i: {} for i in range(10)}, "pdv_issues": []}
+    result = enrichment_success_rate(
+        ctx, enriched_pdv_metadata=enriched, pdv_cross_references=xrefs
+    )
+    assert result.passed  # 9/10 = 90%
+
+
+def test_enrichment_success_rate_warns():
+    ctx = build_asset_context()
+    enriched = {"written_count": 5, "write_errors": [{}] * 5, "coord_failures": 0}
+    xrefs = {"matches": {i: {} for i in range(10)}, "pdv_issues": []}
+    result = enrichment_success_rate(
+        ctx, enriched_pdv_metadata=enriched, pdv_cross_references=xrefs
+    )
+    assert not result.passed  # 5/10 = 50%
+
+
+def test_coord_transform_check_passes():
+    ctx = build_asset_context()
+    enriched = {"written_count": 10, "write_errors": [], "coord_failures": 0}
+    result = coord_transform_check(ctx, enriched_pdv_metadata=enriched)
+    assert result.passed
+
+
+def test_coord_transform_check_warns():
+    ctx = build_asset_context()
+    enriched = {"written_count": 10, "write_errors": [], "coord_failures": 3}
+    result = coord_transform_check(ctx, enriched_pdv_metadata=enriched)
+    assert not result.passed
+```
+
+### Step 5: Update `test_asset_dag_loads`
+
+In `tests/test_assets.py`, update to verify checks are registered:
+
+```python
+def test_asset_dag_loads():
+    """Verify the Dagster Definitions object loads with all assets and checks."""
+    from helix_dagster import defs
+
+    repo = defs.get_repository_def()
+    asset_keys = {ak.to_user_string() for ak in repo.asset_graph.get_all_asset_keys()}
+
+    expected_assets = {
+        "raw_experiment_log",
+        "pdv_trace_inventory",
+        "validated_rows",
+        "pdv_cross_references",
+        "enriched_pdv_metadata",
+        "quality_report",
+    }
+    for name in expected_assets:
+        assert name in asset_keys, f"Missing asset: {name}"
+
+    # Verify asset checks are registered
+    check_keys = {
+        str(ck) for ck in repo.asset_graph.asset_check_keys
+    }
+    assert len(check_keys) >= 5, f"Expected at least 5 asset checks, got {len(check_keys)}"
+```
+
+### Step 6: Verify
+
+```bash
+poetry run pytest tests/test_checks.py -v
+poetry run pytest tests/ -v
+```
+
+### Step 7: Commit, push, create PR
+
+```bash
+git add -A
+git commit -m "feat: add Dagster asset checks for data quality surfacing
+
+Added @asset_check functions for each critical asset that produce
+pass/warn/fail indicators visible in the Dagster UI:
+
+- zero_inventory: ERROR if pdv_trace_inventory returns 0 items
+- igsn_validity_rate: WARN if <80% of rows have valid IGSNs
+- pdv_match_rate: WARN if <50% of PDV filenames matched
+- igsn_consistency: ERROR if any IGSN mismatch between spreadsheet and Girder
+- enrichment_success_rate: WARN if <90% of matched items enriched
+- coord_transform_check: WARN if any coordinate transforms failed
+
+Checks are advisory and do not block pipeline execution.
+
+Also exposed coord_failures in enriched_pdv_metadata return dict.
+
+Closes #ISSUE_NUMBER"
+git push -u origin feat/asset-checks
+
+gh pr create \
+  --title "feat: add Dagster asset checks for data quality surfacing" \
+  --body "## Summary
+
+Adds \`@asset_check\` functions that evaluate data quality after each critical
+asset materializes, displaying colored pass/warn/fail indicators in the Dagster
+UI. Stage 3 of the refactoring.
+
+## Checks Added
+
+| Check | Asset | Severity | Threshold |
+|-------|-------|----------|-----------|
+| \`zero_inventory\` | \`pdv_trace_inventory\` | ERROR | 0 items |
+| \`igsn_validity_rate\` | \`validated_rows\` | WARN | <80% |
+| \`pdv_match_rate\` | \`pdv_cross_references\` | WARN | <50% |
+| \`igsn_consistency\` | \`pdv_cross_references\` | ERROR | any mismatch |
+| \`enrichment_success_rate\` | \`enriched_pdv_metadata\` | WARN | <90% |
+| \`coord_transform_check\` | \`enriched_pdv_metadata\` | WARN | any failure |
+
+## Changes
+
+- New file: \`helix_dagster/checks.py\` with 6 asset checks
+- \`assets.py\`: Exposed \`coord_failures\` in \`enriched_pdv_metadata\` return dict
+- \`__init__.py\`: Registered all checks in Definitions
+- \`tests/test_checks.py\`: 12 unit tests
+
+Closes #ISSUE_NUMBER" \
+  --base refactor/asset-dag
+```
+
+## Verification Checklist
+
+- [ ] GitHub issue created
+- [ ] `checks.py` created with 6 asset check functions
+- [ ] `enriched_pdv_metadata` returns `coord_failures`
+- [ ] All checks registered in `__init__.py` Definitions
+- [ ] 12 check tests pass
+- [ ] Existing tests still pass
+- [ ] PR created against `refactor/asset-dag`

--- a/claude_code_prompt_stage4_processing_manifest.md
+++ b/claude_code_prompt_stage4_processing_manifest.md
@@ -1,0 +1,318 @@
+# Claude Code Prompt — Stage 4: Add processing manifest with Girder write-back
+
+**Read CLAUDE.md first.** Then read `ROADMAP_aimdl_refactor.md` for full context.
+Then read `issues/06-processing-manifest.md`.
+
+**Prerequisite:** Stages 1–3 must be merged.
+
+## GitHub Issue
+
+```bash
+gh issue create \
+  --title "feat: add processing manifest with Girder write-back" \
+  --body-file issues/06-processing-manifest.md \
+  --label "enhancement"
+```
+
+## Branch
+
+```bash
+git checkout refactor/asset-dag
+git pull
+git checkout -b feat/processing-manifest
+```
+
+## Overview
+
+Add a `processing_manifest` asset at the end of the DAG that writes a structured
+processing record to the source spreadsheet's Girder item as `meta.processing_status`.
+This provides an audit trail, enables idempotency (sensor can check before
+reprocessing), and gives Girder-side visibility into pipeline status.
+
+## Changes
+
+### Step 1: Add `processing_manifest` asset to assets.py
+
+Add a new asset that depends on `quality_report` and all upstream data:
+
+```python
+from datetime import datetime, timezone
+from helix_dagster import __version__ as PIPELINE_VERSION
+```
+
+(If `__version__` doesn't exist in `__init__.py`, add `__version__ = "0.2.0"` there.)
+
+```python
+@asset
+def processing_manifest(
+    context: AssetExecutionContext,
+    config: ExperimentLogConfig,
+    quality_report: dict,
+    validated_rows: dict,
+    pdv_cross_references: dict,
+    enriched_pdv_metadata: dict,
+    girder: GirderConnection,
+) -> dict:
+    """Write a processing status record to the source spreadsheet's Girder item.
+
+    This provides:
+    - Audit trail: persistent record of what the pipeline did
+    - Idempotency: sensor can check before triggering reruns
+    - Cross-system visibility: Girder UI shows processing status
+    """
+    df = validated_rows["dataframe"]
+    total_rows = len(df)
+    valid_igsn_count = int(df["valid_igsn"].notna().sum())
+    matched_count = len(pdv_cross_references["matches"])
+    written_count = enriched_pdv_metadata["written_count"]
+    coord_failures = enriched_pdv_metadata.get("coord_failures", 0)
+
+    igsn_issues = validated_rows["igsn_issues"]
+    pdv_issues = pdv_cross_references["pdv_issues"]
+    write_errors = enriched_pdv_metadata["write_errors"]
+
+    issues_summary = {
+        "igsn_invalid": sum(1 for i in igsn_issues if i.get("issue") == "invalid_format"),
+        "igsn_missing": sum(1 for i in igsn_issues if i.get("issue") == "missing"),
+        "pdv_not_found": sum(1 for i in pdv_issues if i.get("type") == "not_found"),
+        "pdv_ambiguous": sum(1 for i in pdv_issues if i.get("type") == "ambiguous"),
+        "igsn_mismatch": sum(1 for i in pdv_issues if i.get("type") == "igsn_mismatch"),
+        "write_errors": len(write_errors),
+        "coord_failures": coord_failures,
+    }
+
+    has_issues = any(v > 0 for v in issues_summary.values())
+    status = "completed_with_warnings" if has_issues else "completed_clean"
+
+    manifest = {
+        "last_processed": datetime.now(timezone.utc).isoformat(),
+        "dagster_run_id": context.run_id,
+        "pipeline_version": PIPELINE_VERSION,
+        "total_rows": total_rows,
+        "rows_valid_igsn": valid_igsn_count,
+        "rows_matched_pdv": matched_count,
+        "rows_enriched": written_count,
+        "status": status,
+        "issues_summary": issues_summary,
+    }
+
+    # Write to the source spreadsheet's Girder item
+    try:
+        girder.addMetadataToItem(config.item_id, {"processing_status": manifest})
+        context.log.info(
+            "Wrote processing manifest to Girder item %s: status=%s",
+            config.item_id,
+            status,
+        )
+    except Exception as exc:
+        context.log.error(
+            "Failed to write processing manifest to Girder item %s: %s",
+            config.item_id,
+            exc,
+        )
+        manifest["write_failed"] = True
+
+    context.add_output_metadata({
+        "status": MetadataValue.text(status),
+        "total_rows": MetadataValue.int(total_rows),
+        "rows_enriched": MetadataValue.int(written_count),
+        "has_issues": MetadataValue.bool(has_issues),
+        "source_item_id": MetadataValue.text(config.item_id),
+    })
+
+    return manifest
+```
+
+**Important:** This asset needs `config: ExperimentLogConfig` to know which
+Girder item to write to. The `ExperimentLogConfig` is already defined and used
+by `raw_experiment_log`. In Dagster, all assets in a job share the same run
+config, so `processing_manifest` can access the same config.
+
+### Step 2: Update `__init__.py` to register the new asset
+
+```python
+from helix_dagster.assets import (
+    alpss_results_inventory,    # if Stage 5 is merged, otherwise omit
+    enriched_pdv_metadata,
+    pdv_cross_references,
+    pdv_trace_inventory,
+    process_helix_assets_job,
+    processing_manifest,
+    quality_report,
+    raw_experiment_log,
+    validated_rows,
+)
+```
+
+Add `processing_manifest` to the assets list in `Definitions`.
+
+### Step 3: Update `process_helix_assets_job` selection
+
+If the job uses `AssetSelection.all()`, no change is needed — the new asset
+is automatically included. If it uses an explicit list, add `processing_manifest`.
+
+### Step 4: Add a `__version__` to the package if it doesn't exist
+
+In `helix_dagster/__init__.py`, if there's no `__version__`, add near the top:
+
+```python
+__version__ = "0.2.0"
+```
+
+This is referenced by the manifest for provenance tracking.
+
+### Step 5: Add tests
+
+Add to `tests/test_assets.py`:
+
+```python
+def test_processing_manifest_clean():
+    """Test manifest for a run with no issues."""
+    from unittest.mock import MagicMock
+    from helix_dagster.assets import processing_manifest as manifest_fn, ExperimentLogConfig
+
+    df = pd.DataFrame([
+        {"Sample_IGSN": "ABCDEF12345", "PDV_FileName": "shot001",
+         "valid_igsn": "ABCDEF12345"},
+    ])
+    validated = {"dataframe": df, "igsn_issues": []}
+    xrefs = {"matches": {0: {"_id": "a1"}}, "pdv_issues": []}
+    enriched = {"written_count": 1, "write_errors": [], "coord_failures": 0}
+    report = {"igsn_issues": [], "pdv_issues": [], "write_errors": [],
+              "summary": {"total_igsn_issues": 0, "total_pdv_issues": 0,
+                          "total_write_errors": 0}}
+
+    config = ExperimentLogConfig(item_id="test_item_123", filename="test.csv")
+    mock_girder = MagicMock()
+
+    ctx = build_asset_context()
+    result = manifest_fn(
+        context=ctx,
+        config=config,
+        quality_report=report,
+        validated_rows=validated,
+        pdv_cross_references=xrefs,
+        enriched_pdv_metadata=enriched,
+        girder=mock_girder,
+    )
+
+    assert result["status"] == "completed_clean"
+    assert result["total_rows"] == 1
+    assert result["rows_enriched"] == 1
+    assert result["issues_summary"]["igsn_invalid"] == 0
+    mock_girder.addMetadataToItem.assert_called_once()
+
+
+def test_processing_manifest_with_warnings():
+    """Test manifest for a run with issues."""
+    from unittest.mock import MagicMock
+    from helix_dagster.assets import processing_manifest as manifest_fn, ExperimentLogConfig
+
+    df = pd.DataFrame([
+        {"Sample_IGSN": "INVALID", "PDV_FileName": "shot001",
+         "valid_igsn": None},
+    ])
+    validated = {
+        "dataframe": df,
+        "igsn_issues": [{"issue": "invalid_format", "value": "INVALID", "row": 0}],
+    }
+    xrefs = {"matches": {}, "pdv_issues": [{"type": "not_found", "row": 0}]}
+    enriched = {"written_count": 0, "write_errors": [], "coord_failures": 0}
+    report = {"igsn_issues": validated["igsn_issues"],
+              "pdv_issues": xrefs["pdv_issues"], "write_errors": [],
+              "summary": {}}
+
+    config = ExperimentLogConfig(item_id="test_item_456", filename="test.csv")
+    mock_girder = MagicMock()
+
+    ctx = build_asset_context()
+    result = manifest_fn(
+        context=ctx,
+        config=config,
+        quality_report=report,
+        validated_rows=validated,
+        pdv_cross_references=xrefs,
+        enriched_pdv_metadata=enriched,
+        girder=mock_girder,
+    )
+
+    assert result["status"] == "completed_with_warnings"
+    assert result["issues_summary"]["igsn_invalid"] == 1
+    assert result["issues_summary"]["pdv_not_found"] == 1
+```
+
+Update `test_asset_dag_loads` to include `"processing_manifest"` in expected assets.
+
+### Step 6: Verify
+
+```bash
+poetry run pytest tests/ -v
+```
+
+### Step 7: Commit, push, create PR
+
+```bash
+git add -A
+git commit -m "feat: add processing manifest with Girder write-back
+
+Added processing_manifest asset that writes a structured processing record
+to the source spreadsheet's Girder item as meta.processing_status. This
+provides an audit trail, enables idempotency (sensor can check before
+reprocessing), and gives Girder-side visibility into pipeline status.
+
+Manifest includes: timestamp, Dagster run ID, pipeline version, row counts,
+enrichment counts, status (completed_clean/completed_with_warnings), and
+a detailed issues_summary breakdown.
+
+Closes #ISSUE_NUMBER"
+git push -u origin feat/processing-manifest
+
+gh pr create \
+  --title "feat: add processing manifest with Girder write-back" \
+  --body "## Summary
+
+Adds a \`processing_manifest\` asset that writes a structured processing
+record to the source spreadsheet's Girder item. Stage 4 of the refactoring.
+
+## What it writes to Girder
+
+\`meta.processing_status\` on the source spreadsheet item:
+\`\`\`json
+{
+  \"status\": \"completed_with_warnings\",
+  \"total_rows\": 45,
+  \"rows_valid_igsn\": 42,
+  \"rows_matched_pdv\": 40,
+  \"rows_enriched\": 38,
+  \"dagster_run_id\": \"abc123\",
+  \"issues_summary\": { ... }
+}
+\`\`\`
+
+## Why
+
+- **Audit trail:** Persistent record linked to source data in Girder
+- **Idempotency:** Sensor can check status before triggering reruns
+- **Cross-system visibility:** Girder web UI shows processing status
+
+## Changes
+
+- \`assets.py\`: Added \`processing_manifest\` asset
+- \`__init__.py\`: Registered new asset, added \`__version__\`
+- \`tests/test_assets.py\`: 2 new tests (clean run, warnings run)
+
+Closes #ISSUE_NUMBER" \
+  --base refactor/asset-dag
+```
+
+## Verification Checklist
+
+- [ ] GitHub issue created
+- [ ] `processing_manifest` asset added to assets.py
+- [ ] Writes `meta.processing_status` to source Girder item
+- [ ] Status is `completed_clean` or `completed_with_warnings`
+- [ ] `__version__` added to package
+- [ ] Registered in `__init__.py` Definitions
+- [ ] Both tests pass (clean + warnings scenarios)
+- [ ] All existing tests still pass
+- [ ] PR created against `refactor/asset-dag`

--- a/claude_code_prompt_stage5_alpss_inventory.md
+++ b/claude_code_prompt_stage5_alpss_inventory.md
@@ -1,0 +1,226 @@
+# Claude Code Prompt — Stage 5: Add ALPSS results inventory for quality reporting
+
+**Read CLAUDE.md first.** Then read `ROADMAP_aimdl_refactor.md`.
+Then read `issues/03-alpss-results-inventory.md`.
+
+**Prerequisite:** Stages 1–4 must be merged. The `pdv_trace_inventory` asset,
+asset checks, and processing manifest must already exist.
+
+## GitHub Issue
+
+```bash
+gh issue create \
+  --title "feat: add ALPSS results inventory for quality reporting" \
+  --body-file issues/03-alpss-results-inventory.md \
+  --label "enhancement"
+```
+
+## Branch
+
+```bash
+git checkout refactor/asset-dag
+git pull
+git checkout -b feat/alpss-results-inventory
+```
+
+## Overview
+
+Add an `alpss_results_inventory` asset that fetches `pdv_alpss_result` items
+from the `/aimdl/datafiles` endpoint. Enhance `quality_report` to include
+ALPSS processing completeness metrics.
+
+## Changes
+
+### Step 1: Add `alpss_results_inventory` asset
+
+In `helix_dagster/assets.py`, add a new asset:
+
+```python
+from helix_dagster.constants import ALPSS_RESULT_DATA_TYPE
+
+@asset
+def alpss_results_inventory(
+    context: AssetExecutionContext,
+    girder: GirderConnection,
+) -> list:
+    """Fetch ALPSS result items via the /aimdl/datafiles endpoint.
+
+    Returns items with meta.data_type='pdv_alpss_result'. Used for
+    quality reporting on ALPSS processing completeness.
+    """
+    items = fetch_all_aimdl_datafiles(girder, ALPSS_RESULT_DATA_TYPE)
+
+    igsns = set()
+    for item in items:
+        igsn = item.get("meta", {}).get("igsn")
+        if igsn:
+            igsns.add(igsn)
+
+    context.add_output_metadata({
+        "item_count": MetadataValue.int(len(items)),
+        "unique_igsns": MetadataValue.int(len(igsns)),
+        "data_type": MetadataValue.text(ALPSS_RESULT_DATA_TYPE),
+    })
+    return items
+```
+
+### Step 2: Enhance `quality_report` to include ALPSS completeness
+
+Update the `quality_report` asset to accept `alpss_results_inventory` as an
+additional upstream dependency:
+
+```python
+@asset
+def quality_report(
+    context: AssetExecutionContext,
+    validated_rows: dict,
+    pdv_cross_references: dict,
+    enriched_pdv_metadata: dict,
+    alpss_results_inventory: list,
+) -> dict:
+    """Aggregate all issues and ALPSS completeness metrics."""
+    igsn_issues = validated_rows["igsn_issues"]
+    pdv_issues = pdv_cross_references["pdv_issues"]
+    write_errors = enriched_pdv_metadata["write_errors"]
+    matches = pdv_cross_references["matches"]
+
+    # ALPSS completeness: which matched PDV traces have ALPSS results?
+    alpss_igsns = set()
+    for item in alpss_results_inventory:
+        igsn = item.get("meta", {}).get("igsn")
+        if igsn:
+            alpss_igsns.add(igsn)
+
+    matched_igsns = set()
+    df = validated_rows["dataframe"]
+    for row_idx in matches:
+        row_igsn = df.loc[row_idx].get("valid_igsn")
+        if row_igsn:
+            matched_igsns.add(row_igsn)
+
+    igsns_with_alpss = matched_igsns & alpss_igsns
+    igsns_without_alpss = matched_igsns - alpss_igsns
+
+    report = {
+        "igsn_issues": igsn_issues,
+        "pdv_issues": pdv_issues,
+        "write_errors": write_errors,
+        "alpss_completeness": {
+            "matched_igsns": len(matched_igsns),
+            "igsns_with_alpss_results": len(igsns_with_alpss),
+            "igsns_without_alpss_results": len(igsns_without_alpss),
+            "missing_igsns": sorted(igsns_without_alpss),
+        },
+        "summary": {
+            "total_igsn_issues": len(igsn_issues),
+            "total_pdv_issues": len(pdv_issues),
+            "total_write_errors": len(write_errors),
+            "alpss_coverage_pct": (
+                round(100 * len(igsns_with_alpss) / len(matched_igsns), 1)
+                if matched_igsns else 0.0
+            ),
+        },
+    }
+
+    context.add_output_metadata({
+        "total_igsn_issues": MetadataValue.int(len(igsn_issues)),
+        "total_pdv_issues": MetadataValue.int(len(pdv_issues)),
+        "total_write_errors": MetadataValue.int(len(write_errors)),
+        "alpss_coverage_pct": MetadataValue.float(
+            report["summary"]["alpss_coverage_pct"]
+        ),
+        "igsns_without_alpss": MetadataValue.int(len(igsns_without_alpss)),
+    })
+    return report
+```
+
+### Step 3: Update `__init__.py`
+
+Add `alpss_results_inventory` to the imports and Definitions assets list.
+Make sure `processing_manifest` (from Stage 4) is also in the list.
+
+### Step 4: Update tests
+
+Update `test_asset_dag_loads` to include `"alpss_results_inventory"` in the
+expected asset set.
+
+Add a test for the quality report's ALPSS completeness section:
+
+```python
+def test_quality_report_alpss_completeness():
+    """Verify quality_report includes ALPSS completeness metrics."""
+    df = pd.DataFrame([
+        {"Sample_IGSN": "ABCDEF12345", "PDV_FileName": "shot001",
+         "valid_igsn": "ABCDEF12345"},
+        {"Sample_IGSN": "ABCDEF12346", "PDV_FileName": "shot002",
+         "valid_igsn": "ABCDEF12346"},
+    ])
+    validated = {"dataframe": df, "igsn_issues": []}
+    pdv_xrefs = {
+        "matches": {0: {"_id": "a1"}, 1: {"_id": "b1"}},
+        "pdv_issues": [],
+    }
+    enriched = {"written_count": 2, "write_errors": [], "coord_failures": 0}
+    alpss_items = [
+        {"meta": {"igsn": "ABCDEF12345", "data_type": "pdv_alpss_result"}},
+        # ABCDEF12346 has no ALPSS result
+    ]
+
+    ctx = build_asset_context()
+    from helix_dagster.assets import quality_report as quality_report_fn
+    report = quality_report_fn(
+        context=ctx,
+        validated_rows=validated,
+        pdv_cross_references=pdv_xrefs,
+        enriched_pdv_metadata=enriched,
+        alpss_results_inventory=alpss_items,
+    )
+    assert report["alpss_completeness"]["igsns_with_alpss_results"] == 1
+    assert report["alpss_completeness"]["igsns_without_alpss_results"] == 1
+    assert "ABCDEF12346" in report["alpss_completeness"]["missing_igsns"]
+    assert report["summary"]["alpss_coverage_pct"] == 50.0
+```
+
+### Step 5: Verify, commit, push, create PR
+
+```bash
+poetry run pytest tests/ -v
+
+git add -A
+git commit -m "feat: add ALPSS results inventory for quality reporting
+
+Added alpss_results_inventory asset that fetches pdv_alpss_result items
+via /aimdl/datafiles. Enhanced quality_report to include ALPSS processing
+completeness metrics (coverage percentage, IGSNs missing ALPSS results).
+
+Closes #ISSUE_NUMBER"
+git push -u origin feat/alpss-results-inventory
+
+gh pr create \
+  --title "feat: add ALPSS results inventory for quality reporting" \
+  --body "## Summary
+
+Adds an \`alpss_results_inventory\` asset and enhances the quality report with
+ALPSS processing completeness metrics. Stage 5 of the refactoring.
+
+## Changes
+
+- **assets.py**: Added \`alpss_results_inventory\` asset. Enhanced \`quality_report\`
+  with ALPSS coverage percentage and list of IGSNs missing results.
+- **__init__.py**: Added new asset to Definitions
+- **tests**: Updated \`test_asset_dag_loads\`, added ALPSS completeness test
+
+Closes #ISSUE_NUMBER" \
+  --base refactor/asset-dag
+```
+
+## Verification Checklist
+
+- [ ] GitHub issue created
+- [ ] `alpss_results_inventory` asset added
+- [ ] `quality_report` enhanced with ALPSS completeness
+- [ ] `__init__.py` updated
+- [ ] `test_asset_dag_loads` updated
+- [ ] ALPSS completeness test added and passing
+- [ ] All tests pass
+- [ ] PR created against `refactor/asset-dag`

--- a/claude_code_prompt_stage6_optimize_sensor.md
+++ b/claude_code_prompt_stage6_optimize_sensor.md
@@ -1,0 +1,246 @@
+# Claude Code Prompt — Stage 6: Optimize sensor to avoid recursive folder crawl
+
+**Read CLAUDE.md first.** Then read `ROADMAP_aimdl_refactor.md`.
+Then read `issues/04-optimize-sensor.md`.
+
+**Prerequisite:** Stages 1–5 must be merged. The processing manifest (Stage 4)
+must exist so the sensor can optionally check it.
+
+## GitHub Issue
+
+```bash
+gh issue create \
+  --title "feat: optimize sensor to avoid recursive folder crawl" \
+  --body-file issues/04-optimize-sensor.md \
+  --label "enhancement"
+```
+
+## Branch
+
+```bash
+git checkout refactor/asset-dag
+git pull
+git checkout -b feat/optimize-sensor
+```
+
+## Overview
+
+The `helix_folder_sensor` currently calls `list_all_spreadsheet_items()`, which
+recursively walks the HELIX folder tree listing items in every subfolder. Replace
+this with a targeted query that fetches only recent items, sorted by creation date.
+
+Optionally integrate with the processing manifest: if a spreadsheet already has
+`meta.processing_status.status == "completed_clean"` and hasn't been modified
+since `last_processed`, skip it.
+
+## Changes
+
+### Step 1: Add a non-recursive recent-items helper to girder_io.py
+
+Add to `helix_dagster/girder_io.py`:
+
+```python
+def list_recent_spreadsheets(client, folder_id, limit=100):
+    """List recently created spreadsheet items in a Girder folder.
+
+    Unlike list_all_spreadsheet_items(), this does NOT recursively walk
+    subfolders. It queries items sorted by creation date (newest first)
+    and filters for CSV/XLSX extensions.
+
+    Parameters
+    ----------
+    client : GirderClient
+        Authenticated Girder client.
+    folder_id : str
+        The Girder folder ID to search.
+    limit : int
+        Maximum number of items to return.
+
+    Returns
+    -------
+    list[dict]
+        Girder item dicts for spreadsheet files, newest first.
+    """
+    items = client.get(
+        "item",
+        parameters={
+            "folderId": folder_id,
+            "sort": "created",
+            "sortdir": -1,
+            "limit": limit,
+        },
+    )
+    return [i for i in items if i["name"].endswith((".csv", ".xlsx", ".xls"))]
+```
+
+Mark `list_all_spreadsheet_items` with a deprecation comment:
+
+```python
+def list_all_spreadsheet_items(client, folder_id):
+    """Recursively list all CSV/XLSX items in a Girder folder.
+
+    .. deprecated::
+        Use list_recent_spreadsheets() for sensor polling. This function
+        performs a recursive folder crawl that scales poorly.
+    """
+    # ... existing implementation unchanged
+```
+
+### Step 2: Update the sensor
+
+In `helix_dagster/sensors.py`:
+
+```python
+import json
+
+from dagster import RunRequest, SensorEvaluationContext, sensor
+
+from helix_dagster.constants import HELIX_FOLDER_ID
+from helix_dagster.assets import process_helix_assets_job
+from helix_dagster.girder_io import list_recent_spreadsheets
+from helix_dagster.resources import GirderConnection
+
+
+@sensor(job=process_helix_assets_job, minimum_interval_seconds=3600)
+def helix_folder_sensor(context: SensorEvaluationContext, girder: GirderConnection):
+    """Poll for new experiment log spreadsheets in the HELIX folder.
+
+    Uses a sorted recent-items query instead of recursive folder crawling.
+    Tracks seen item IDs in the cursor to avoid reprocessing.
+    """
+    cursor_data = json.loads(context.cursor or '{"seen": []}')
+    seen = set(cursor_data["seen"])
+
+    items = list_recent_spreadsheets(girder, HELIX_FOLDER_ID, limit=100)
+
+    new_seen = set(seen)
+    requests = []
+    for item in items:
+        item_id = item["_id"]
+        if item_id not in seen:
+            # Optionally check processing manifest
+            existing_meta = item.get("meta", {})
+            processing_status = existing_meta.get("processing_status", {})
+            if processing_status.get("status") == "completed_clean":
+                context.log.info(
+                    "Skipping %s — already processed cleanly on %s",
+                    item["name"],
+                    processing_status.get("last_processed", "unknown"),
+                )
+                new_seen.add(item_id)
+                continue
+
+            requests.append(
+                RunRequest(
+                    run_key=item_id,
+                    run_config={
+                        "ops": {
+                            "raw_experiment_log": {
+                                "config": {
+                                    "item_id": item_id,
+                                    "filename": item["name"],
+                                }
+                            }
+                        }
+                    },
+                )
+            )
+            new_seen.add(item_id)
+
+    context.update_cursor(json.dumps({"seen": list(new_seen)}))
+    return requests
+```
+
+**Key changes:**
+- `list_all_spreadsheet_items` → `list_recent_spreadsheets`
+- Checks `meta.processing_status` before triggering a run
+- Items processed with `completed_clean` status are added to `seen` without reprocessing
+- Items with `completed_with_warnings` are allowed to reprocess (operator might have fixed the data)
+
+**Note:** The `meta` field may not be present in the item listing response
+depending on the Girder endpoint. If `item.get("meta")` is always empty from
+the listing endpoint, you'll need to fetch each item individually with
+`girder.get(f"item/{item_id}")` to check the manifest. Only do this for
+items not already in `seen` to avoid excessive API calls.
+
+### Step 3: Add tests
+
+Add to `tests/test_girder_io.py`:
+
+```python
+from helix_dagster.girder_io import list_recent_spreadsheets
+
+def test_list_recent_spreadsheets():
+    client = MagicMock()
+    client.get.return_value = [
+        {"name": "log_2025.csv", "_id": "c1", "created": "2025-03-01T00:00:00Z"},
+        {"name": "data.tdms", "_id": "c2", "created": "2025-03-01T00:00:00Z"},
+        {"name": "results.xlsx", "_id": "c3", "created": "2025-02-28T00:00:00Z"},
+    ]
+    result = list_recent_spreadsheets(client, "folder123", limit=50)
+    assert len(result) == 2  # only .csv and .xlsx, not .tdms
+    assert result[0]["name"] == "log_2025.csv"
+    assert result[1]["name"] == "results.xlsx"
+    client.get.assert_called_once_with(
+        "item",
+        parameters={
+            "folderId": "folder123",
+            "sort": "created",
+            "sortdir": -1,
+            "limit": 50,
+        },
+    )
+```
+
+### Step 4: Update CLAUDE.md
+
+Remove `list_all_spreadsheet_items` from the workflow description. Add a note
+about the sensor's manifest-aware behavior.
+
+### Step 5: Verify, commit, push, create PR
+
+```bash
+poetry run pytest tests/ -v
+
+git add -A
+git commit -m "feat: optimize sensor to avoid recursive folder crawl
+
+Replaced list_all_spreadsheet_items() recursive folder walk in the sensor
+with list_recent_spreadsheets() which queries the 100 most recent items
+sorted by creation date. Also integrated with the processing manifest:
+spreadsheets already processed cleanly are skipped.
+
+Closes #ISSUE_NUMBER"
+git push -u origin feat/optimize-sensor
+
+gh pr create \
+  --title "feat: optimize sensor to avoid recursive folder crawl" \
+  --body "## Summary
+
+Replaces the recursive folder crawl in \`helix_folder_sensor\` with a targeted
+recent-items query, and integrates with the processing manifest to skip
+already-processed spreadsheets. Stage 6 of the refactoring.
+
+## Changes
+
+- **girder_io.py**: Added \`list_recent_spreadsheets()\`, deprecated
+  \`list_all_spreadsheet_items()\`
+- **sensors.py**: Updated to use \`list_recent_spreadsheets()\` and check
+  \`meta.processing_status\` before triggering reruns
+- **tests**: Added test for new function
+- **CLAUDE.md**: Updated workflow description
+
+Closes #ISSUE_NUMBER" \
+  --base refactor/asset-dag
+```
+
+## Verification Checklist
+
+- [ ] GitHub issue created
+- [ ] `list_recent_spreadsheets` function added
+- [ ] `list_all_spreadsheet_items` marked deprecated
+- [ ] Sensor updated to use new function and check manifest
+- [ ] Test added and passing
+- [ ] All existing tests still pass
+- [ ] CLAUDE.md updated
+- [ ] PR created against `refactor/asset-dag`

--- a/helix_dagster/constants.py
+++ b/helix_dagster/constants.py
@@ -6,6 +6,27 @@ PDV_FOLDER_ID = os.environ.get("PDV_FOLDER_ID")
 
 IGSN_PATTERN = re.compile(r"[A-Za-z]{6}\d{5}(?:-[A-Za-z0-9]+)?")
 
+# /aimdl endpoint data types
+# These correspond to meta.data_type values set on Girder items
+AIMDL_DATA_TYPES = {
+    "pdv_trace": "pdv_trace",
+    "pdv_alpss_result": "pdv_alpss_result",
+    "pdv_alpss_output": "pdv_alpss_output",
+    "xrd_raw": "xrd_raw",
+    "xrd_derived": "xrd_derived",
+    "xrd_metadata": "xrd_metadata",
+    "xrd_calibrant_raw": "xrd_calibrant_raw",
+    "xrd_calibrant_derived": "xrd_calibrant_derived",
+    "xrf_raw": "xrf_raw",
+}
+
+# Default data type for PDV trace matching (used by pdv_trace_inventory asset)
+PDV_TRACE_DATA_TYPE = os.environ.get("PDV_TRACE_DATA_TYPE", "pdv_trace")
+ALPSS_RESULT_DATA_TYPE = os.environ.get("ALPSS_RESULT_DATA_TYPE", "pdv_alpss_result")
+
+# Hard limit imposed by the /aimdl/datafiles endpoint
+AIMDL_PAGE_LIMIT = 100
+
 COLUMN_MAP = {
     "Timestamp": "Timestamp",
     "Exp_ID": "Exp_ID",

--- a/helix_dagster/girder_io.py
+++ b/helix_dagster/girder_io.py
@@ -5,6 +5,8 @@ import math
 
 import pandas as pd
 
+from helix_dagster.constants import AIMDL_PAGE_LIMIT
+
 
 def list_all_spreadsheet_items(client, folder_id):
     """Recursively list all CSV/XLSX items in a Girder folder."""
@@ -42,3 +44,72 @@ def nan_to_none(val):
     if isinstance(val, float) and math.isnan(val):
         return None
     return val
+
+
+def fetch_aimdl_datatypes(client):
+    """Fetch the list of available meta.data_type values from /aimdl/datatype.
+
+    Returns a list of strings, e.g. ["pdv_trace", "xrd_raw", ...].
+    """
+    return client.get("aimdl/datatype")
+
+
+def fetch_aimdl_datafiles(client, data_type, limit=100, offset=0):
+    """Fetch a single page of items from /aimdl/datafiles.
+
+    Parameters
+    ----------
+    client : GirderClient
+        Authenticated Girder client.
+    data_type : str
+        The meta.data_type value to filter by (e.g., "pdv_trace").
+    limit : int
+        Max items per page (capped at 100 by endpoint).
+    offset : int
+        Pagination offset.
+
+    Returns
+    -------
+    list[dict]
+        List of Girder item dicts with _id, name, meta.igsn, meta.data_type,
+        size, created, folderId, etc.
+    """
+    return client.get(
+        "aimdl/datafiles",
+        parameters={
+            "dataType": data_type,
+            "limit": min(limit, AIMDL_PAGE_LIMIT),
+            "offset": offset,
+        },
+    )
+
+
+def fetch_all_aimdl_datafiles(client, data_type):
+    """Paginate through all items of a given data type via /aimdl/datafiles.
+
+    The endpoint has a hard limit of 100 per page. This function fetches all
+    pages and returns the concatenated result.
+
+    Parameters
+    ----------
+    client : GirderClient
+        Authenticated Girder client.
+    data_type : str
+        The meta.data_type value to filter by.
+
+    Returns
+    -------
+    list[dict]
+        All matching Girder item dicts.
+    """
+    all_items = []
+    offset = 0
+    while True:
+        batch = fetch_aimdl_datafiles(client, data_type, offset=offset)
+        if not batch:
+            break
+        all_items.extend(batch)
+        if len(batch) < AIMDL_PAGE_LIMIT:
+            break
+        offset += AIMDL_PAGE_LIMIT
+    return all_items

--- a/issues/01-add-aimdl-helpers.md
+++ b/issues/01-add-aimdl-helpers.md
@@ -1,0 +1,32 @@
+# Issue: Add `/aimdl` endpoint helper functions to girder_io.py
+
+## Problem
+
+The pipeline currently discovers PDV data files by fetching ALL items from the PDV
+folder via `girder.get("item", parameters={"folderId": PDV_FOLDER_ID, "limit": 100000})`.
+This is expensive, slow, and scales poorly as data accumulates.
+
+The Girder instance now has an `/aimdl/datafiles` endpoint that performs an indexed
+MongoDB query by `meta.data_type`, returning only relevant items without directory
+traversal.
+
+## Proposed Change
+
+Add helper functions to `girder_io.py` for the `/aimdl` endpoint:
+
+- `fetch_aimdl_datafiles(client, data_type, limit, offset)` — single page fetch
+- `fetch_all_aimdl_datafiles(client, data_type)` — paginator (endpoint caps at 100/page)
+- `fetch_aimdl_datatypes(client)` — list available data types
+
+Add constants to `constants.py`:
+
+- `AIMDL_DATA_TYPES` dict mapping friendly names to `meta.data_type` strings
+- `PDV_TRACE_DATA_TYPE` defaulting to `"pdv_trace"`
+
+Add unit tests with mocked Girder responses.
+
+No changes to existing asset behavior in this stage.
+
+## Labels
+
+`enhancement`, `backend`, `stage-1`

--- a/issues/02-replace-pdv-inventory.md
+++ b/issues/02-replace-pdv-inventory.md
@@ -1,0 +1,30 @@
+# Issue: Replace `pdv_inventory` with `/aimdl/datafiles` endpoint
+
+## Problem
+
+The `pdv_inventory` asset fetches up to 100,000 items from the PDV folder via
+a single Girder REST call. This is the primary performance bottleneck in the
+pipeline. Most items are irrelevant to the spreadsheet being processed.
+
+## Proposed Change
+
+Replace `pdv_inventory` with a new `pdv_trace_inventory` asset that uses the
+`/aimdl/datafiles?dataType=pdv_trace` endpoint. This performs an indexed MongoDB
+query returning only items with the correct `data_type` and an existing IGSN.
+
+Additionally:
+- Update `pdv_cross_references` to depend on `pdv_trace_inventory`
+- Add IGSN consistency checking (cross-check spreadsheet IGSN vs item `meta.igsn`)
+- Remove `PDV_FOLDER_ID` from constants
+- Update all tests and `__init__.py` Definitions
+
+## Migration Note
+
+The `/aimdl/datafiles` endpoint requires `meta.igsn` to exist on items.
+Until IGSN tagging is complete on all PDV files, the new inventory may return
+fewer items than the old folder-based approach. The implementation should log
+a warning if the inventory is suspiciously small.
+
+## Labels
+
+`enhancement`, `backend`, `stage-2`

--- a/issues/03-alpss-results-inventory.md
+++ b/issues/03-alpss-results-inventory.md
@@ -1,0 +1,23 @@
+# Issue: Add ALPSS results inventory for quality reporting
+
+## Problem
+
+The pipeline currently has no visibility into whether ALPSS processing has been
+completed for matched PDV traces. The quality report only covers IGSN validation,
+PDV filename matching, and metadata write errors — it doesn't report on processing
+coverage.
+
+## Proposed Change
+
+Add an `alpss_results_inventory` asset that fetches `pdv_alpss_result` items via
+the `/aimdl/datafiles` endpoint. Enhance the `quality_report` to include:
+
+- Which matched PDV traces have corresponding ALPSS results?
+- Which ALPSS results exist for IGSNs not in the current spreadsheet?
+- Overall processing completeness metrics
+
+This gives operators visibility into the ALPSS processing pipeline's health.
+
+## Labels
+
+`enhancement`, `backend`, `stage-3`

--- a/issues/04-optimize-sensor.md
+++ b/issues/04-optimize-sensor.md
@@ -1,0 +1,21 @@
+# Issue: Optimize sensor to avoid recursive folder crawl
+
+## Problem
+
+The `helix_folder_sensor` calls `list_all_spreadsheet_items()` which recursively
+walks the entire HELIX folder tree every hour, listing items in every subfolder
+to find new CSV/XLSX files. As the folder tree grows, this becomes increasingly slow.
+
+## Proposed Change
+
+Replace the recursive crawl with a targeted query:
+- Fetch recent items from the HELIX folder sorted by creation date (newest first)
+- Only check a limited number of recent items instead of the full tree
+- Use the sensor cursor to track the last-seen timestamp, not just seen item IDs
+
+This reduces the sensor evaluation from walking potentially hundreds of folders
+to a single paginated query for recent items.
+
+## Labels
+
+`enhancement`, `backend`, `stage-4`

--- a/issues/05-asset-checks.md
+++ b/issues/05-asset-checks.md
@@ -1,0 +1,29 @@
+# Issue: Add Dagster asset checks for error surfacing
+
+## Problem
+
+The current pipeline treats most bad outcomes as data rather than failures.
+Invalid IGSNs become `igsn_issues`, unmatched PDV files become `pdv_issues`,
+write exceptions are swallowed into `write_errors`. Dagster always shows green
+unless an exception escapes the asset body. An operator looking at the Dagster
+UI sees a successful run even when 50% of rows failed validation or matching.
+
+## Proposed Change
+
+Add `@asset_check` functions that produce colored pass/warn/fail indicators
+in the Dagster UI, separate from asset materialization status. Six checks:
+
+| Check | Asset | Severity | Trigger |
+|-------|-------|----------|---------|
+| `zero_inventory` | `pdv_trace_inventory` | ERROR | Inventory returned 0 items |
+| `igsn_validity_rate` | `validated_rows` | WARN | <80% valid IGSNs |
+| `pdv_match_rate` | `pdv_cross_references` | WARN | <50% rows matched |
+| `igsn_consistency` | `pdv_cross_references` | ERROR | Any IGSN mismatch |
+| `enrichment_success_rate` | `enriched_pdv_metadata` | WARN | <90% enriched |
+| `no_write_errors` | `enriched_pdv_metadata` | ERROR | Any write exception |
+
+Checks are defined in a new `checks.py` module and registered in Definitions.
+
+## Labels
+
+`enhancement`, `backend`, `stage-3`

--- a/issues/06-processing-manifest.md
+++ b/issues/06-processing-manifest.md
@@ -1,0 +1,47 @@
+# Issue: Add processing manifest (write-back to Girder)
+
+## Problem
+
+There is no durable record of what was processed, when, or what the outcome was.
+The sensor cursor (a list of seen item IDs) lives in Dagster's storage and gets
+lost on reset. There's no way to look at a spreadsheet in Girder and know whether
+it was successfully processed, or what the outcome was.
+
+This creates three problems:
+1. **No idempotency**: Resetting Dagster reprocesses everything.
+2. **No audit trail**: No cross-system visibility into processing history.
+3. **No verification**: Cannot compare expected vs. actual processing outcomes.
+
+## Proposed Change
+
+Add a `processing_manifest` asset that runs after `quality_report` and writes
+`meta.processing_status` to the source spreadsheet Girder item. The manifest
+records:
+
+```json
+{
+  "processing_status": {
+    "last_processed": "2026-04-02T14:30:00Z",
+    "dagster_run_id": "abc123...",
+    "status": "completed_with_warnings",
+    "total_rows": 45,
+    "rows_valid_igsn": 42,
+    "rows_matched_pdv": 40,
+    "rows_enriched": 38,
+    "issues_summary": {
+      "igsn_issues": 3,
+      "pdv_issues": 2,
+      "write_errors": 0,
+      "igsn_mismatches": 0
+    }
+  }
+}
+```
+
+Update the sensor to check the manifest before triggering reprocessing:
+- If the spreadsheet has `meta.processing_status.status == "completed"` and
+  hasn't been modified since `last_processed`, skip it.
+
+## Labels
+
+`enhancement`, `backend`, `stage-4`

--- a/tests/test_girder_io.py
+++ b/tests/test_girder_io.py
@@ -1,0 +1,79 @@
+"""Tests for the /aimdl endpoint helper functions."""
+
+from unittest.mock import MagicMock
+
+from helix_dagster.girder_io import (
+    fetch_aimdl_datatypes,
+    fetch_aimdl_datafiles,
+    fetch_all_aimdl_datafiles,
+)
+
+
+def _make_item(name, igsn, data_type, item_id=None):
+    """Helper to create a mock Girder item dict."""
+    return {
+        "_id": item_id or f"id_{name}",
+        "name": name,
+        "meta": {"igsn": igsn, "data_type": data_type},
+        "size": 1024,
+        "created": "2025-01-01T00:00:00Z",
+        "folderId": "folder123",
+        "lowerName": name.lower(),
+    }
+
+
+def test_fetch_datatypes():
+    client = MagicMock()
+    client.get.return_value = ["pdv_trace", "xrd_raw", "pdv_alpss_result"]
+    result = fetch_aimdl_datatypes(client)
+    client.get.assert_called_once_with("aimdl/datatype")
+    assert result == ["pdv_trace", "xrd_raw", "pdv_alpss_result"]
+
+
+def test_fetch_datafiles_single_page():
+    items = [_make_item(f"file{i}.tdms", "ABCDEF12345", "pdv_trace") for i in range(5)]
+    client = MagicMock()
+    client.get.return_value = items
+    result = fetch_aimdl_datafiles(client, "pdv_trace", limit=100, offset=0)
+    client.get.assert_called_once_with(
+        "aimdl/datafiles",
+        parameters={"dataType": "pdv_trace", "limit": 100, "offset": 0},
+    )
+    assert len(result) == 5
+
+
+def test_fetch_datafiles_respects_limit_cap():
+    """Verify that limit is capped at 100 even if caller requests more."""
+    client = MagicMock()
+    client.get.return_value = []
+    fetch_aimdl_datafiles(client, "pdv_trace", limit=500, offset=0)
+    call_params = client.get.call_args[1]["parameters"]
+    assert call_params["limit"] == 100
+
+
+def test_fetch_all_paginates():
+    """fetch_all should paginate until a short page is returned."""
+    page1 = [_make_item(f"f{i}", "IGSN1", "pdv_trace") for i in range(100)]
+    page2 = [_make_item(f"f{i}", "IGSN1", "pdv_trace") for i in range(100, 130)]
+
+    client = MagicMock()
+    client.get.side_effect = [page1, page2]
+    result = fetch_all_aimdl_datafiles(client, "pdv_trace")
+    assert len(result) == 130
+    assert client.get.call_count == 2
+
+
+def test_fetch_all_empty():
+    client = MagicMock()
+    client.get.return_value = []
+    result = fetch_all_aimdl_datafiles(client, "pdv_trace")
+    assert result == []
+
+
+def test_fetch_all_single_page():
+    items = [_make_item(f"f{i}", "IGSN1", "pdv_trace") for i in range(50)]
+    client = MagicMock()
+    client.get.return_value = items
+    result = fetch_all_aimdl_datafiles(client, "pdv_trace")
+    assert len(result) == 50
+    assert client.get.call_count == 1  # No second page needed


### PR DESCRIPTION
## Summary

- Added `fetch_aimdl_datatypes()`, `fetch_aimdl_datafiles()`, and `fetch_all_aimdl_datafiles()` to `girder_io.py` for querying the indexed `/aimdl/datafiles` Girder endpoint
- Added `AIMDL_DATA_TYPES`, `PDV_TRACE_DATA_TYPE`, `ALPSS_RESULT_DATA_TYPE`, and `AIMDL_PAGE_LIMIT` constants to `constants.py`
- Added 6 unit tests with mocked Girder responses in `tests/test_girder_io.py`

No changes to existing asset behavior. This is Stage 1 of the refactoring described in `ROADMAP_aimdl_refactor.md`.

Closes #8

## Test plan

- [x] All 6 new tests pass (verified with mocked imports)
- [x] No changes to existing functions in `girder_io.py`
- [ ] Verify `pytest` passes in CI environment with correct Python version

🤖 Generated with [Claude Code](https://claude.com/claude-code)