### PR TITLE
feat: replace pdv_inventory with /aimdl/datafiles endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,17 +17,19 @@ back to Girder items.
 
 ## Key conventions
 - Run `dagster dev` from the repo root to start the Dagster webserver
-- Environment variables: GIRDER_API_URL, GIRDER_TOKEN, HELIX_FOLDER_ID, PDV_FOLDER_ID
+- Environment variables: GIRDER_API_URL, GIRDER_TOKEN, HELIX_FOLDER_ID, PDV_TRACE_DATA_TYPE
 - The coordinate transform YAML path should be set via COORD_TRANSFORMS_YAML env var
 - Use `pytest` for testing; tests go in `tests/`
 - Python ≥3.9
 
 ## Workflow
 1. Sensor polls a Girder folder for new experiment log spreadsheets (CSV/XLSX)
-2. Pipeline downloads, parses, validates IGSNs, cross-references PDV files,
-   transforms coordinates, writes enriched metadata to Girder
-3. Quality issues (missing IGSNs, unmatched PDV files, IGSN mismatches) are
-   reported as structured metadata on the Dagster run
+2. Pipeline downloads, parses, validates IGSNs
+3. PDV trace inventory fetched via /aimdl/datafiles?dataType=pdv_trace
+   (indexed MongoDB query, no directory crawling)
+4. Cross-references PDV filenames and checks IGSN consistency
+5. Writes enriched metadata to matched Girder items
+6. Quality issues reported as structured metadata on the Dagster run
 
 ## Important domain context
 - Each spreadsheet row represents one laser shock experiment (one "shot")

--- a/helix_dagster/__init__.py
+++ b/helix_dagster/__init__.py
@@ -3,7 +3,7 @@ from dagster import Definitions, EnvVar
 from helix_dagster.assets import (
     enriched_pdv_metadata,
     pdv_cross_references,
-    pdv_inventory,
+    pdv_trace_inventory,
     process_helix_assets_job,
     quality_report,
     raw_experiment_log,
@@ -15,7 +15,7 @@ from helix_dagster.sensors import helix_folder_sensor
 defs = Definitions(
     assets=[
         raw_experiment_log,
-        pdv_inventory,
+        pdv_trace_inventory,
         validated_rows,
         pdv_cross_references,
         enriched_pdv_metadata,

--- a/helix_dagster/assets.py
+++ b/helix_dagster/assets.py
@@ -10,9 +10,9 @@ from dagster import (
     define_asset_job,
 )
 
-from helix_dagster.constants import COLUMN_MAP, PDV_FOLDER_ID
+from helix_dagster.constants import COLUMN_MAP, PDV_TRACE_DATA_TYPE
 from helix_dagster.coordinates import transform_station_to_sample
-from helix_dagster.girder_io import download_and_read, nan_to_none
+from helix_dagster.girder_io import download_and_read, fetch_all_aimdl_datafiles, nan_to_none
 from helix_dagster.matching import match_pdv_file
 from helix_dagster.resources import GirderConnection
 from helix_dagster.validation import NpEncoder, validate_igsn
@@ -43,20 +43,37 @@ def raw_experiment_log(
 
 
 @asset
-def pdv_inventory(
+def pdv_trace_inventory(
     context: AssetExecutionContext,
     girder: GirderConnection,
 ) -> list:
-    """Fetch all items from the PDV folder via Girder API."""
-    items = girder.get(
-        "item",
-        parameters={"folderId": PDV_FOLDER_ID, "limit": 100000},
-    )
-    context.add_output_metadata(
-        {
-            "item_count": MetadataValue.int(len(items)),
-        }
-    )
+    """Fetch PDV trace items via the /aimdl/datafiles endpoint.
+
+    Uses an indexed MongoDB query filtered by meta.data_type='pdv_trace'
+    instead of crawling the PDV folder tree. Items must have meta.igsn
+    set to appear in results.
+    """
+    items = fetch_all_aimdl_datafiles(girder, PDV_TRACE_DATA_TYPE)
+
+    # Extract unique IGSNs from the inventory
+    igsns = set()
+    for item in items:
+        igsn = item.get("meta", {}).get("igsn")
+        if igsn:
+            igsns.add(igsn)
+
+    context.add_output_metadata({
+        "item_count": MetadataValue.int(len(items)),
+        "unique_igsns": MetadataValue.int(len(igsns)),
+        "data_type": MetadataValue.text(PDV_TRACE_DATA_TYPE),
+    })
+
+    if len(items) == 0:
+        context.log.warning(
+            "pdv_trace_inventory returned 0 items. This may indicate that "
+            "meta.igsn has not been tagged on PDV files yet."
+        )
+
     return items
 
 
@@ -98,7 +115,7 @@ def validated_rows(
 def pdv_cross_references(
     context: AssetExecutionContext,
     validated_rows: dict,
-    pdv_inventory: list,
+    pdv_trace_inventory: list,
 ) -> dict:
     """Match PDV filenames to inventory items. Pure matching, no network calls."""
     df = validated_rows["dataframe"]
@@ -107,9 +124,20 @@ def pdv_cross_references(
 
     for idx, row in df.iterrows():
         pdv_filename = row.get("PDV_FileName")
-        pdv_item, issue = match_pdv_file(pdv_inventory, pdv_filename)
+        pdv_item, issue = match_pdv_file(pdv_trace_inventory, pdv_filename)
         if pdv_item is not None:
             matches[idx] = pdv_item
+            # Cross-check IGSN consistency
+            row_igsn = row.get("valid_igsn")
+            item_igsn = pdv_item.get("meta", {}).get("igsn")
+            if row_igsn and item_igsn and row_igsn != item_igsn:
+                pdv_issues.append({
+                    "pdv_filename": pdv_filename,
+                    "type": "igsn_mismatch",
+                    "row": idx,
+                    "spreadsheet_igsn": row_igsn,
+                    "item_igsn": item_igsn,
+                })
         if issue is not None:
             issue["row"] = idx
             pdv_issues.append(issue)
@@ -117,12 +145,14 @@ def pdv_cross_references(
     matched_count = len(matches)
     not_found_count = sum(1 for i in pdv_issues if i["type"] == "not_found")
     ambiguous_count = sum(1 for i in pdv_issues if i["type"] == "ambiguous")
+    mismatch_count = sum(1 for i in pdv_issues if i["type"] == "igsn_mismatch")
 
     context.add_output_metadata(
         {
             "matched_count": MetadataValue.int(matched_count),
             "not_found_count": MetadataValue.int(not_found_count),
             "ambiguous_count": MetadataValue.int(ambiguous_count),
+            "igsn_mismatch_count": MetadataValue.int(mismatch_count),
         }
     )
     return {"matches": matches, "pdv_issues": pdv_issues}

--- a/helix_dagster/constants.py
+++ b/helix_dagster/constants.py
@@ -2,7 +2,6 @@ import os
 import re
 
 HELIX_FOLDER_ID = os.environ.get("HELIX_FOLDER_ID")
-PDV_FOLDER_ID = os.environ.get("PDV_FOLDER_ID")
 
 IGSN_PATTERN = re.compile(r"[A-Za-z]{6}\d{5}(?:-[A-Za-z0-9]+)?")
 

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -53,8 +53,8 @@ def test_pdv_cross_references_pure():
     )
 
     pdv_items = [
-        {"name": "shot001_ch1.tdms", "_id": "a1"},
-        {"name": "shot002_ch1.tdms", "_id": "b1"},
+        {"name": "shot001_ch1.tdms", "_id": "a1", "meta": {"igsn": "ABCDEF12345", "data_type": "pdv_trace"}},
+        {"name": "shot002_ch1.tdms", "_id": "b1", "meta": {"igsn": "ABCDEF12346", "data_type": "pdv_trace"}},
     ]
 
     validated = {"dataframe": df, "igsn_issues": []}
@@ -63,7 +63,7 @@ def test_pdv_cross_references_pure():
     result = pdv_cross_references_fn(
         context=ctx,
         validated_rows=validated,
-        pdv_inventory=pdv_items,
+        pdv_trace_inventory=pdv_items,
     )
 
     matches = result["matches"]
@@ -94,7 +94,7 @@ def test_asset_dag_loads():
 
     expected = {
         "raw_experiment_log",
-        "pdv_inventory",
+        "pdv_trace_inventory",
         "validated_rows",
         "pdv_cross_references",
         "enriched_pdv_metadata",
@@ -102,3 +102,27 @@ def test_asset_dag_loads():
     }
     for name in expected:
         assert name in asset_keys, f"Missing asset: {name}"
+
+
+def test_igsn_mismatch_detection():
+    """Verify that IGSN mismatches between spreadsheet and Girder item are flagged."""
+    df = pd.DataFrame([
+        {"Sample_IGSN": "ABCDEF12345", "PDV_FileName": "shot001",
+         "valid_igsn": "ABCDEF12345"},
+    ])
+    pdv_items = [
+        {"name": "shot001_ch1.tdms", "_id": "a1",
+         "meta": {"igsn": "XXXXXX99999", "data_type": "pdv_trace"}},
+    ]
+    validated = {"dataframe": df, "igsn_issues": []}
+    ctx = build_asset_context()
+    result = pdv_cross_references_fn(
+        context=ctx,
+        validated_rows=validated,
+        pdv_trace_inventory=pdv_items,
+    )
+    issues = result["pdv_issues"]
+    mismatch_issues = [i for i in issues if i["type"] == "igsn_mismatch"]
+    assert len(mismatch_issues) == 1
+    assert mismatch_issues[0]["spreadsheet_igsn"] == "ABCDEF12345"
+    assert mismatch_issues[0]["item_igsn"] == "XXXXXX99999"


### PR DESCRIPTION
## Summary

- Replaced `pdv_inventory` asset with `pdv_trace_inventory`, switching from a 100,000-item folder crawl to an indexed MongoDB query via the `/aimdl/datafiles` endpoint
- Added IGSN consistency checking in `pdv_cross_references` — mismatches between spreadsheet and Girder item IGSNs are now flagged
- Removed `PDV_FOLDER_ID` environment variable dependency

Stage 2 of the refactoring in `ROADMAP_aimdl_refactor.md`.

## Migration Note

The `/aimdl/datafiles` endpoint requires `meta.igsn` to exist on items. Until IGSN tagging is complete, some PDV files may not appear in the inventory. The asset logs a warning if the inventory is empty.

## Test plan

- [ ] `test_pdv_cross_references_pure` passes with updated param name and mock items
- [ ] `test_asset_dag_loads` passes with `pdv_trace_inventory` in expected set
- [ ] `test_igsn_mismatch_detection` passes (new test)
- [ ] Dagster Definitions load successfully

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)