### PR TITLE
feat: add Dagster asset checks for data quality surfacing

### DIFF
--- a/helix_dagster/__init__.py
+++ b/helix_dagster/__init__.py
@@ -9,6 +9,14 @@ from helix_dagster.assets import (
     raw_experiment_log,
     validated_rows,
 )
+from helix_dagster.checks import (
+    coord_transform_check,
+    enrichment_success_rate,
+    igsn_consistency,
+    igsn_validity_rate,
+    pdv_match_rate,
+    zero_inventory,
+)
 from helix_dagster.resources import GirderConnection, GirderCredentials
 from helix_dagster.sensors import helix_folder_sensor
 
@@ -20,6 +28,14 @@ defs = Definitions(
         pdv_cross_references,
         enriched_pdv_metadata,
         quality_report,
+    ],
+    asset_checks=[
+        zero_inventory,
+        igsn_validity_rate,
+        pdv_match_rate,
+        igsn_consistency,
+        enrichment_success_rate,
+        coord_transform_check,
     ],
     jobs=[process_helix_assets_job],
     sensors=[helix_folder_sensor],

--- a/helix_dagster/assets.py
+++ b/helix_dagster/assets.py
@@ -184,7 +184,11 @@ def enriched_pdv_metadata(
             "coordinate_transform_failures": MetadataValue.int(coord_failures),
         }
     )
-    return {"written_count": written_count, "write_errors": write_errors}
+    return {
+        "written_count": written_count,
+        "write_errors": write_errors,
+        "coord_failures": coord_failures,
+    }
 
 
 @asset

--- a/helix_dagster/checks.py
+++ b/helix_dagster/checks.py
@@ -1,0 +1,147 @@
+"""Dagster asset checks for data quality surfacing.
+
+These checks evaluate the output of each critical asset and produce
+pass/warn/fail indicators visible in the Dagster UI. They do NOT block
+pipeline execution — they are advisory.
+"""
+
+from dagster import (
+    AssetCheckResult,
+    AssetCheckSeverity,
+    AssetIn,
+    asset_check,
+)
+
+
+@asset_check(asset="pdv_inventory")
+def zero_inventory(context, pdv_inventory):
+    """ERROR if the PDV inventory returned zero items.
+
+    This typically means the PDV folder is empty or misconfigured.
+    """
+    count = len(pdv_inventory)
+    passed = count > 0
+    return AssetCheckResult(
+        passed=passed,
+        severity=AssetCheckSeverity.ERROR,
+        metadata={"item_count": count},
+        description=(
+            f"Inventory contains {count} items."
+            if passed
+            else "Inventory is EMPTY. Check PDV folder configuration."
+        ),
+    )
+
+
+@asset_check(asset="validated_rows")
+def igsn_validity_rate(context, validated_rows):
+    """WARN if fewer than 80% of rows have valid IGSNs."""
+    df = validated_rows["dataframe"]
+    total = len(df)
+    if total == 0:
+        return AssetCheckResult(
+            passed=True,
+            severity=AssetCheckSeverity.WARN,
+            metadata={"total_rows": 0, "validity_rate": 0.0},
+            description="No rows to validate.",
+        )
+    valid_count = df["valid_igsn"].notna().sum()
+    rate = valid_count / total
+    passed = bool(rate >= 0.8)
+    return AssetCheckResult(
+        passed=passed,
+        severity=AssetCheckSeverity.WARN,
+        metadata={
+            "total_rows": total,
+            "valid_count": int(valid_count),
+            "validity_rate": round(float(rate), 3),
+        },
+        description=f"IGSN validity rate: {rate:.1%} ({valid_count}/{total})",
+    )
+
+
+@asset_check(asset="pdv_cross_references", additional_ins={"validated_rows": AssetIn("validated_rows")})
+def pdv_match_rate(context, pdv_cross_references, validated_rows):
+    """WARN if fewer than 50% of rows with PDV filenames were matched."""
+    df = validated_rows["dataframe"]
+    import math
+    rows_with_pdv = sum(
+        1
+        for _, row in df.iterrows()
+        if row.get("PDV_FileName") is not None
+        and not (isinstance(row.get("PDV_FileName"), float) and math.isnan(row.get("PDV_FileName")))
+        and str(row.get("PDV_FileName")).strip() != ""
+    )
+    matched_count = len(pdv_cross_references["matches"])
+    rate = matched_count / rows_with_pdv if rows_with_pdv > 0 else 0.0
+    passed = rate >= 0.5
+    return AssetCheckResult(
+        passed=passed,
+        severity=AssetCheckSeverity.WARN,
+        metadata={
+            "rows_with_pdv_filename": rows_with_pdv,
+            "matched_count": matched_count,
+            "match_rate": round(rate, 3),
+        },
+        description=f"PDV match rate: {rate:.1%} ({matched_count}/{rows_with_pdv})",
+    )
+
+
+@asset_check(asset="pdv_cross_references")
+def igsn_consistency(context, pdv_cross_references):
+    """ERROR if any matched PDV item has a different IGSN than the spreadsheet row."""
+    issues = pdv_cross_references["pdv_issues"]
+    mismatches = [i for i in issues if i.get("type") == "igsn_mismatch"]
+    passed = len(mismatches) == 0
+    metadata = {"mismatch_count": len(mismatches)}
+    if mismatches:
+        examples = mismatches[:3]
+        metadata["examples"] = str(examples)
+    return AssetCheckResult(
+        passed=passed,
+        severity=AssetCheckSeverity.ERROR,
+        metadata=metadata,
+        description=(
+            "No IGSN mismatches."
+            if passed
+            else f"{len(mismatches)} IGSN mismatch(es) between spreadsheet and Girder items."
+        ),
+    )
+
+
+@asset_check(asset="enriched_pdv_metadata", additional_ins={"pdv_cross_references": AssetIn("pdv_cross_references")})
+def enrichment_success_rate(context, enriched_pdv_metadata, pdv_cross_references):
+    """WARN if fewer than 90% of matched items were successfully enriched."""
+    matched_count = len(pdv_cross_references["matches"])
+    written_count = enriched_pdv_metadata["written_count"]
+    rate = written_count / matched_count if matched_count > 0 else 0.0
+    error_count = len(enriched_pdv_metadata["write_errors"])
+    passed = rate >= 0.9
+    return AssetCheckResult(
+        passed=passed,
+        severity=AssetCheckSeverity.WARN,
+        metadata={
+            "matched_count": matched_count,
+            "written_count": written_count,
+            "error_count": error_count,
+            "success_rate": round(rate, 3),
+        },
+        description=f"Enrichment success rate: {rate:.1%} ({written_count}/{matched_count})",
+    )
+
+
+@asset_check(asset="enriched_pdv_metadata")
+def coord_transform_check(context, enriched_pdv_metadata):
+    """WARN if any coordinate transformations failed."""
+    failures = enriched_pdv_metadata.get("coord_failures", 0)
+    passed = failures == 0
+    return AssetCheckResult(
+        passed=passed,
+        severity=AssetCheckSeverity.WARN,
+        metadata={"coord_failures": failures},
+        description=(
+            "All coordinate transforms succeeded."
+            if passed
+            else f"{failures} coordinate transform failure(s). Check COORD_TRANSFORMS_YAML."
+        ),
+    )

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -86,13 +86,13 @@ def test_pdv_cross_references_pure():
 
 
 def test_asset_dag_loads():
-    """Verify the Dagster Definitions object loads and contains all six assets."""
+    """Verify the Dagster Definitions object loads with all assets and checks."""
     from helix_dagster import defs
 
     repo = defs.get_repository_def()
     asset_keys = {ak.to_user_string() for ak in repo.asset_graph.get_all_asset_keys()}
 
-    expected = {
+    expected_assets = {
         "raw_experiment_log",
         "pdv_inventory",
         "validated_rows",
@@ -100,5 +100,11 @@ def test_asset_dag_loads():
         "enriched_pdv_metadata",
         "quality_report",
     }
-    for name in expected:
+    for name in expected_assets:
         assert name in asset_keys, f"Missing asset: {name}"
+
+    # Verify asset checks are registered
+    check_keys = {
+        str(ck) for ck in repo.asset_graph.asset_check_keys
+    }
+    assert len(check_keys) >= 5, f"Expected at least 5 asset checks, got {len(check_keys)}"

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -1,0 +1,123 @@
+"""Tests for Dagster asset checks."""
+
+import pandas as pd
+from dagster import build_asset_context
+
+from helix_dagster.checks import (
+    coord_transform_check,
+    enrichment_success_rate,
+    igsn_consistency,
+    igsn_validity_rate,
+    pdv_match_rate,
+    zero_inventory,
+)
+
+
+def test_zero_inventory_fails_on_empty():
+    ctx = build_asset_context()
+    result = zero_inventory(ctx, pdv_inventory=[])
+    assert not result.passed
+    assert result.severity.value == "ERROR"
+
+
+def test_zero_inventory_passes_with_items():
+    ctx = build_asset_context()
+    result = zero_inventory(ctx, pdv_inventory=[{"_id": "a"}])
+    assert result.passed
+
+
+def test_igsn_validity_rate_passes_above_threshold():
+    ctx = build_asset_context()
+    validated = {
+        "dataframe": pd.DataFrame({"valid_igsn": ["A", "B", "C", "D", None]}),
+        "igsn_issues": [],
+    }
+    result = igsn_validity_rate(ctx, validated_rows=validated)
+    assert result.passed  # 4/5 = 80%
+
+
+def test_igsn_validity_rate_warns_below_threshold():
+    ctx = build_asset_context()
+    validated = {
+        "dataframe": pd.DataFrame({"valid_igsn": ["A", None, None, None, None]}),
+        "igsn_issues": [],
+    }
+    result = igsn_validity_rate(ctx, validated_rows=validated)
+    assert not result.passed  # 1/5 = 20%
+    assert result.severity.value == "WARN"
+
+
+def test_pdv_match_rate_passes():
+    ctx = build_asset_context()
+    validated = {
+        "dataframe": pd.DataFrame({"PDV_FileName": ["shot1", "shot2"]}),
+        "igsn_issues": [],
+    }
+    xrefs = {"matches": {0: {}, 1: {}}, "pdv_issues": []}
+    result = pdv_match_rate(ctx, pdv_cross_references=xrefs, validated_rows=validated)
+    assert result.passed  # 2/2 = 100%
+
+
+def test_pdv_match_rate_warns():
+    ctx = build_asset_context()
+    validated = {
+        "dataframe": pd.DataFrame({"PDV_FileName": ["shot1", "shot2", "shot3", "shot4"]}),
+        "igsn_issues": [],
+    }
+    xrefs = {"matches": {0: {}}, "pdv_issues": []}
+    result = pdv_match_rate(ctx, pdv_cross_references=xrefs, validated_rows=validated)
+    assert not result.passed  # 1/4 = 25%
+
+
+def test_igsn_consistency_passes():
+    ctx = build_asset_context()
+    xrefs = {"matches": {}, "pdv_issues": []}
+    result = igsn_consistency(ctx, pdv_cross_references=xrefs)
+    assert result.passed
+
+
+def test_igsn_consistency_errors_on_mismatch():
+    ctx = build_asset_context()
+    xrefs = {
+        "matches": {},
+        "pdv_issues": [
+            {"type": "igsn_mismatch", "spreadsheet_igsn": "A", "item_igsn": "B"},
+        ],
+    }
+    result = igsn_consistency(ctx, pdv_cross_references=xrefs)
+    assert not result.passed
+    assert result.severity.value == "ERROR"
+
+
+def test_enrichment_success_rate_passes():
+    ctx = build_asset_context()
+    enriched = {"written_count": 9, "write_errors": [], "coord_failures": 0}
+    xrefs = {"matches": {i: {} for i in range(10)}, "pdv_issues": []}
+    result = enrichment_success_rate(
+        ctx, enriched_pdv_metadata=enriched, pdv_cross_references=xrefs
+    )
+    assert result.passed  # 9/10 = 90%
+
+
+def test_enrichment_success_rate_warns():
+    ctx = build_asset_context()
+    enriched = {"written_count": 5, "write_errors": [{}] * 5, "coord_failures": 0}
+    xrefs = {"matches": {i: {} for i in range(10)}, "pdv_issues": []}
+    result = enrichment_success_rate(
+        ctx, enriched_pdv_metadata=enriched, pdv_cross_references=xrefs
+    )
+    assert not result.passed  # 5/10 = 50%
+
+
+def test_coord_transform_check_passes():
+    ctx = build_asset_context()
+    enriched = {"written_count": 10, "write_errors": [], "coord_failures": 0}
+    result = coord_transform_check(ctx, enriched_pdv_metadata=enriched)
+    assert result.passed
+
+
+def test_coord_transform_check_warns():
+    ctx = build_asset_context()
+    enriched = {"written_count": 10, "write_errors": [], "coord_failures": 3}
+    result = coord_transform_check(ctx, enriched_pdv_metadata=enriched)
+    assert not result.passed


### PR DESCRIPTION
## Summary

Adds `@asset_check` functions that evaluate data quality after each critical
asset materializes, displaying colored pass/warn/fail indicators in the Dagster
UI. Stage 3 of the refactoring.

## Checks Added

| Check | Asset | Severity | Threshold |
|-------|-------|----------|-----------|
| `zero_inventory` | `pdv_inventory` | ERROR | 0 items |
| `igsn_validity_rate` | `validated_rows` | WARN | <80% |
| `pdv_match_rate` | `pdv_cross_references` | WARN | <50% |
| `igsn_consistency` | `pdv_cross_references` | ERROR | any mismatch |
| `enrichment_success_rate` | `enriched_pdv_metadata` | WARN | <90% |
| `coord_transform_check` | `enriched_pdv_metadata` | WARN | any failure |

## Changes

- New file: `helix_dagster/checks.py` with 6 asset checks
- `assets.py`: Exposed `coord_failures` in `enriched_pdv_metadata` return dict
- `__init__.py`: Registered all checks in Definitions
- `tests/test_checks.py`: 12 unit tests

## Test plan

- [x] All 12 check tests pass
- [x] All existing tests pass (15 total)

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)