### PR TITLE
feat: add processing manifest with Girder write-back

### DIFF
--- a/helix_dagster/__init__.py
+++ b/helix_dagster/__init__.py
@@ -1,3 +1,5 @@
+__version__ = "0.2.0"
+
 from dagster import Definitions, EnvVar
 
 from helix_dagster.assets import (
@@ -5,6 +7,7 @@ from helix_dagster.assets import (
     pdv_cross_references,
     pdv_inventory,
     process_helix_assets_job,
+    processing_manifest,
     quality_report,
     raw_experiment_log,
     validated_rows,
@@ -28,6 +31,7 @@ defs = Definitions(
         pdv_cross_references,
         enriched_pdv_metadata,
         quality_report,
+        processing_manifest,
     ],
     asset_checks=[
         zero_inventory,

--- a/helix_dagster/assets.py
+++ b/helix_dagster/assets.py
@@ -1,4 +1,5 @@
 import json
+from datetime import datetime, timezone
 
 import pandas as pd
 from dagster import (
@@ -10,6 +11,7 @@ from dagster import (
     define_asset_job,
 )
 
+from helix_dagster import __version__ as PIPELINE_VERSION
 from helix_dagster.constants import COLUMN_MAP, PDV_FOLDER_ID
 from helix_dagster.coordinates import transform_station_to_sample
 from helix_dagster.girder_io import download_and_read, nan_to_none
@@ -222,6 +224,86 @@ def quality_report(
         }
     )
     return report
+
+
+@asset
+def processing_manifest(
+    context: AssetExecutionContext,
+    config: ExperimentLogConfig,
+    quality_report: dict,
+    validated_rows: dict,
+    pdv_cross_references: dict,
+    enriched_pdv_metadata: dict,
+    girder: GirderConnection,
+) -> dict:
+    """Write a processing status record to the source spreadsheet's Girder item.
+
+    This provides:
+    - Audit trail: persistent record of what the pipeline did
+    - Idempotency: sensor can check before triggering reruns
+    - Cross-system visibility: Girder UI shows processing status
+    """
+    df = validated_rows["dataframe"]
+    total_rows = len(df)
+    valid_igsn_count = int(df["valid_igsn"].notna().sum())
+    matched_count = len(pdv_cross_references["matches"])
+    written_count = enriched_pdv_metadata["written_count"]
+    coord_failures = enriched_pdv_metadata.get("coord_failures", 0)
+
+    igsn_issues = validated_rows["igsn_issues"]
+    pdv_issues = pdv_cross_references["pdv_issues"]
+    write_errors = enriched_pdv_metadata["write_errors"]
+
+    issues_summary = {
+        "igsn_invalid": sum(1 for i in igsn_issues if i.get("issue") == "invalid_format"),
+        "igsn_missing": sum(1 for i in igsn_issues if i.get("issue") == "missing"),
+        "pdv_not_found": sum(1 for i in pdv_issues if i.get("type") == "not_found"),
+        "pdv_ambiguous": sum(1 for i in pdv_issues if i.get("type") == "ambiguous"),
+        "igsn_mismatch": sum(1 for i in pdv_issues if i.get("type") == "igsn_mismatch"),
+        "write_errors": len(write_errors),
+        "coord_failures": coord_failures,
+    }
+
+    has_issues = any(v > 0 for v in issues_summary.values())
+    status = "completed_with_warnings" if has_issues else "completed_clean"
+
+    manifest = {
+        "last_processed": datetime.now(timezone.utc).isoformat(),
+        "dagster_run_id": context.run.run_id,
+        "pipeline_version": PIPELINE_VERSION,
+        "total_rows": total_rows,
+        "rows_valid_igsn": valid_igsn_count,
+        "rows_matched_pdv": matched_count,
+        "rows_enriched": written_count,
+        "status": status,
+        "issues_summary": issues_summary,
+    }
+
+    # Write to the source spreadsheet's Girder item
+    try:
+        girder.addMetadataToItem(config.item_id, {"processing_status": manifest})
+        context.log.info(
+            "Wrote processing manifest to Girder item %s: status=%s",
+            config.item_id,
+            status,
+        )
+    except Exception as exc:
+        context.log.error(
+            "Failed to write processing manifest to Girder item %s: %s",
+            config.item_id,
+            exc,
+        )
+        manifest["write_failed"] = True
+
+    context.add_output_metadata({
+        "status": MetadataValue.text(status),
+        "total_rows": MetadataValue.int(total_rows),
+        "rows_enriched": MetadataValue.int(written_count),
+        "has_issues": MetadataValue.bool(has_issues),
+        "source_item_id": MetadataValue.text(config.item_id),
+    })
+
+    return manifest
 
 
 process_helix_assets_job = define_asset_job(

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -99,6 +99,7 @@ def test_asset_dag_loads():
         "pdv_cross_references",
         "enriched_pdv_metadata",
         "quality_report",
+        "processing_manifest",
     }
     for name in expected_assets:
         assert name in asset_keys, f"Missing asset: {name}"
@@ -108,3 +109,78 @@ def test_asset_dag_loads():
         str(ck) for ck in repo.asset_graph.asset_check_keys
     }
     assert len(check_keys) >= 5, f"Expected at least 5 asset checks, got {len(check_keys)}"
+
+
+def test_processing_manifest_clean():
+    """Test manifest for a run with no issues."""
+    from unittest.mock import MagicMock
+    from helix_dagster.assets import processing_manifest as manifest_fn, ExperimentLogConfig
+
+    df = pd.DataFrame([
+        {"Sample_IGSN": "ABCDEF12345", "PDV_FileName": "shot001",
+         "valid_igsn": "ABCDEF12345"},
+    ])
+    validated = {"dataframe": df, "igsn_issues": []}
+    xrefs = {"matches": {0: {"_id": "a1"}}, "pdv_issues": []}
+    enriched = {"written_count": 1, "write_errors": [], "coord_failures": 0}
+    report = {"igsn_issues": [], "pdv_issues": [], "write_errors": [],
+              "summary": {"total_igsn_issues": 0, "total_pdv_issues": 0,
+                          "total_write_errors": 0}}
+
+    config = ExperimentLogConfig(item_id="test_item_123", filename="test.csv")
+    mock_girder = MagicMock()
+
+    ctx = build_asset_context()
+    result = manifest_fn(
+        context=ctx,
+        config=config,
+        quality_report=report,
+        validated_rows=validated,
+        pdv_cross_references=xrefs,
+        enriched_pdv_metadata=enriched,
+        girder=mock_girder,
+    )
+
+    assert result["status"] == "completed_clean"
+    assert result["total_rows"] == 1
+    assert result["rows_enriched"] == 1
+    assert result["issues_summary"]["igsn_invalid"] == 0
+    mock_girder.addMetadataToItem.assert_called_once()
+
+
+def test_processing_manifest_with_warnings():
+    """Test manifest for a run with issues."""
+    from unittest.mock import MagicMock
+    from helix_dagster.assets import processing_manifest as manifest_fn, ExperimentLogConfig
+
+    df = pd.DataFrame([
+        {"Sample_IGSN": "INVALID", "PDV_FileName": "shot001",
+         "valid_igsn": None},
+    ])
+    validated = {
+        "dataframe": df,
+        "igsn_issues": [{"issue": "invalid_format", "value": "INVALID", "row": 0}],
+    }
+    xrefs = {"matches": {}, "pdv_issues": [{"type": "not_found", "row": 0}]}
+    enriched = {"written_count": 0, "write_errors": [], "coord_failures": 0}
+    report = {"igsn_issues": validated["igsn_issues"],
+              "pdv_issues": xrefs["pdv_issues"], "write_errors": [],
+              "summary": {}}
+
+    config = ExperimentLogConfig(item_id="test_item_456", filename="test.csv")
+    mock_girder = MagicMock()
+
+    ctx = build_asset_context()
+    result = manifest_fn(
+        context=ctx,
+        config=config,
+        quality_report=report,
+        validated_rows=validated,
+        pdv_cross_references=xrefs,
+        enriched_pdv_metadata=enriched,
+        girder=mock_girder,
+    )
+
+    assert result["status"] == "completed_with_warnings"
+    assert result["issues_summary"]["igsn_invalid"] == 1
+    assert result["issues_summary"]["pdv_not_found"] == 1


### PR DESCRIPTION
## Summary

- Added `processing_manifest` asset that writes a structured processing record to the source spreadsheet Girder item as `meta.processing_status`
- Provides audit trail, idempotency (sensor can check before reprocessing), and Girder-side visibility into pipeline status
- Added `__version__ = "0.2.0"` to the package for provenance tracking

## What it writes to Girder

`meta.processing_status` on the source spreadsheet item:
```json
{
  "status": "completed_with_warnings",
  "total_rows": 45,
  "rows_valid_igsn": 42,
  "rows_matched_pdv": 40,
  "rows_enriched": 38,
  "dagster_run_id": "abc123",
  "issues_summary": { ... }
}
```

## Changes

- `assets.py`: Added `processing_manifest` asset
- `__init__.py`: Registered new asset, added `__version__`
- `tests/test_assets.py`: 2 new tests (clean run, warnings run)

## Test plan

- [x] All 40 tests pass, 1 skipped (pre-existing)
- [x] DAG loads test updated to include `processing_manifest`

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)