### PR TITLE
feat: add ALPSS results inventory for quality reporting

### DIFF
--- a/helix_dagster/__init__.py
+++ b/helix_dagster/__init__.py
@@ -3,6 +3,7 @@ __version__ = "0.2.0"
 from dagster import Definitions, EnvVar
 
 from helix_dagster.assets import (
+    alpss_results_inventory,
     enriched_pdv_metadata,
     pdv_cross_references,
     pdv_inventory,
@@ -30,6 +31,7 @@ defs = Definitions(
         validated_rows,
         pdv_cross_references,
         enriched_pdv_metadata,
+        alpss_results_inventory,
         quality_report,
         processing_manifest,
     ],

--- a/helix_dagster/assets.py
+++ b/helix_dagster/assets.py
@@ -12,9 +12,9 @@ from dagster import (
 )
 
 from helix_dagster import __version__ as PIPELINE_VERSION
-from helix_dagster.constants import COLUMN_MAP, PDV_FOLDER_ID
+from helix_dagster.constants import ALPSS_RESULT_DATA_TYPE, COLUMN_MAP, PDV_FOLDER_ID
 from helix_dagster.coordinates import transform_station_to_sample
-from helix_dagster.girder_io import download_and_read, nan_to_none
+from helix_dagster.girder_io import download_and_read, fetch_all_aimdl_datafiles, nan_to_none
 from helix_dagster.matching import match_pdv_file
 from helix_dagster.resources import GirderConnection
 from helix_dagster.validation import NpEncoder, validate_igsn
@@ -194,35 +194,92 @@ def enriched_pdv_metadata(
 
 
 @asset
+def alpss_results_inventory(
+    context: AssetExecutionContext,
+    girder: GirderConnection,
+) -> list:
+    """Fetch ALPSS result items via the /aimdl/datafiles endpoint.
+
+    Returns items with meta.data_type='pdv_alpss_result'. Used for
+    quality reporting on ALPSS processing completeness.
+    """
+    items = fetch_all_aimdl_datafiles(girder, ALPSS_RESULT_DATA_TYPE)
+
+    igsns = set()
+    for item in items:
+        igsn = item.get("meta", {}).get("igsn")
+        if igsn:
+            igsns.add(igsn)
+
+    context.add_output_metadata({
+        "item_count": MetadataValue.int(len(items)),
+        "unique_igsns": MetadataValue.int(len(igsns)),
+        "data_type": MetadataValue.text(ALPSS_RESULT_DATA_TYPE),
+    })
+    return items
+
+
+@asset
 def quality_report(
     context: AssetExecutionContext,
     validated_rows: dict,
     pdv_cross_references: dict,
     enriched_pdv_metadata: dict,
+    alpss_results_inventory: list,
 ) -> dict:
-    """Aggregate all issues from upstream assets into a single report."""
+    """Aggregate all issues and ALPSS completeness metrics."""
     igsn_issues = validated_rows["igsn_issues"]
     pdv_issues = pdv_cross_references["pdv_issues"]
     write_errors = enriched_pdv_metadata["write_errors"]
+    matches = pdv_cross_references["matches"]
+
+    # ALPSS completeness: which matched PDV traces have ALPSS results?
+    alpss_igsns = set()
+    for item in alpss_results_inventory:
+        igsn = item.get("meta", {}).get("igsn")
+        if igsn:
+            alpss_igsns.add(igsn)
+
+    matched_igsns = set()
+    df = validated_rows["dataframe"]
+    for row_idx in matches:
+        row_igsn = df.loc[row_idx].get("valid_igsn")
+        if row_igsn:
+            matched_igsns.add(row_igsn)
+
+    igsns_with_alpss = matched_igsns & alpss_igsns
+    igsns_without_alpss = matched_igsns - alpss_igsns
 
     report = {
         "igsn_issues": igsn_issues,
         "pdv_issues": pdv_issues,
         "write_errors": write_errors,
+        "alpss_completeness": {
+            "matched_igsns": len(matched_igsns),
+            "igsns_with_alpss_results": len(igsns_with_alpss),
+            "igsns_without_alpss_results": len(igsns_without_alpss),
+            "missing_igsns": sorted(igsns_without_alpss),
+        },
         "summary": {
             "total_igsn_issues": len(igsn_issues),
             "total_pdv_issues": len(pdv_issues),
             "total_write_errors": len(write_errors),
+            "alpss_coverage_pct": (
+                round(100 * len(igsns_with_alpss) / len(matched_igsns), 1)
+                if matched_igsns else 0.0
+            ),
         },
     }
 
-    context.add_output_metadata(
-        {
-            "total_igsn_issues": MetadataValue.int(len(igsn_issues)),
-            "total_pdv_issues": MetadataValue.int(len(pdv_issues)),
-            "total_write_errors": MetadataValue.int(len(write_errors)),
-        }
-    )
+    context.add_output_metadata({
+        "total_igsn_issues": MetadataValue.int(len(igsn_issues)),
+        "total_pdv_issues": MetadataValue.int(len(pdv_issues)),
+        "total_write_errors": MetadataValue.int(len(write_errors)),
+        "alpss_coverage_pct": MetadataValue.float(
+            report["summary"]["alpss_coverage_pct"]
+        ),
+        "igsns_without_alpss": MetadataValue.int(len(igsns_without_alpss)),
+    })
     return report
 
 

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -98,6 +98,7 @@ def test_asset_dag_loads():
         "validated_rows",
         "pdv_cross_references",
         "enriched_pdv_metadata",
+        "alpss_results_inventory",
         "quality_report",
         "processing_manifest",
     }
@@ -109,6 +110,40 @@ def test_asset_dag_loads():
         str(ck) for ck in repo.asset_graph.asset_check_keys
     }
     assert len(check_keys) >= 5, f"Expected at least 5 asset checks, got {len(check_keys)}"
+
+
+def test_quality_report_alpss_completeness():
+    """Verify quality_report includes ALPSS completeness metrics."""
+    df = pd.DataFrame([
+        {"Sample_IGSN": "ABCDEF12345", "PDV_FileName": "shot001",
+         "valid_igsn": "ABCDEF12345"},
+        {"Sample_IGSN": "ABCDEF12346", "PDV_FileName": "shot002",
+         "valid_igsn": "ABCDEF12346"},
+    ])
+    validated = {"dataframe": df, "igsn_issues": []}
+    pdv_xrefs = {
+        "matches": {0: {"_id": "a1"}, 1: {"_id": "b1"}},
+        "pdv_issues": [],
+    }
+    enriched = {"written_count": 2, "write_errors": [], "coord_failures": 0}
+    alpss_items = [
+        {"meta": {"igsn": "ABCDEF12345", "data_type": "pdv_alpss_result"}},
+        # ABCDEF12346 has no ALPSS result
+    ]
+
+    ctx = build_asset_context()
+    from helix_dagster.assets import quality_report as quality_report_fn
+    report = quality_report_fn(
+        context=ctx,
+        validated_rows=validated,
+        pdv_cross_references=pdv_xrefs,
+        enriched_pdv_metadata=enriched,
+        alpss_results_inventory=alpss_items,
+    )
+    assert report["alpss_completeness"]["igsns_with_alpss_results"] == 1
+    assert report["alpss_completeness"]["igsns_without_alpss_results"] == 1
+    assert "ABCDEF12346" in report["alpss_completeness"]["missing_igsns"]
+    assert report["summary"]["alpss_coverage_pct"] == 50.0
 
 
 def test_processing_manifest_clean():
@@ -124,8 +159,10 @@ def test_processing_manifest_clean():
     xrefs = {"matches": {0: {"_id": "a1"}}, "pdv_issues": []}
     enriched = {"written_count": 1, "write_errors": [], "coord_failures": 0}
     report = {"igsn_issues": [], "pdv_issues": [], "write_errors": [],
+              "alpss_completeness": {"matched_igsns": 1, "igsns_with_alpss_results": 1,
+                                     "igsns_without_alpss_results": 0, "missing_igsns": []},
               "summary": {"total_igsn_issues": 0, "total_pdv_issues": 0,
-                          "total_write_errors": 0}}
+                          "total_write_errors": 0, "alpss_coverage_pct": 100.0}}
 
     config = ExperimentLogConfig(item_id="test_item_123", filename="test.csv")
     mock_girder = MagicMock()
@@ -165,7 +202,9 @@ def test_processing_manifest_with_warnings():
     enriched = {"written_count": 0, "write_errors": [], "coord_failures": 0}
     report = {"igsn_issues": validated["igsn_issues"],
               "pdv_issues": xrefs["pdv_issues"], "write_errors": [],
-              "summary": {}}
+              "alpss_completeness": {"matched_igsns": 0, "igsns_with_alpss_results": 0,
+                                     "igsns_without_alpss_results": 0, "missing_igsns": []},
+              "summary": {"alpss_coverage_pct": 0.0}}
 
     config = ExperimentLogConfig(item_id="test_item_456", filename="test.csv")
     mock_girder = MagicMock()


### PR DESCRIPTION
## Summary

- Added `alpss_results_inventory` asset that fetches `pdv_alpss_result` items via `/aimdl/datafiles`
- Enhanced `quality_report` with ALPSS processing completeness metrics (coverage %, IGSNs missing results)
- Updated `__init__.py` with new asset in Definitions
- Added `test_quality_report_alpss_completeness` test, updated `test_asset_dag_loads`

Stage 5 of the asset DAG refactoring. Closes #16

## Test plan

- [x] `test_quality_report_alpss_completeness` — verifies ALPSS coverage calculation
- [x] `test_asset_dag_loads` — confirms new asset registered in Definitions
- [x] All 40 non-pre-existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)