### PR TITLE
feat: optimize sensor to avoid recursive folder crawl

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,9 @@ back to Girder items.
 - Python ≥3.9
 
 ## Workflow
-1. Sensor polls a Girder folder for new experiment log spreadsheets (CSV/XLSX)
+1. Sensor polls a Girder folder for recent experiment log spreadsheets (CSV/XLSX)
+   using a sorted recent-items query (not recursive folder crawl). Spreadsheets
+   already processed cleanly (per `meta.processing_status`) are skipped.
 2. Pipeline downloads, parses, validates IGSNs, cross-references PDV files,
    transforms coordinates, writes enriched metadata to Girder
 3. Quality issues (missing IGSNs, unmatched PDV files, IGSN mismatches) are

--- a/helix_dagster/girder_io.py
+++ b/helix_dagster/girder_io.py
@@ -9,7 +9,12 @@ from helix_dagster.constants import AIMDL_PAGE_LIMIT
 
 
 def list_all_spreadsheet_items(client, folder_id):
-    """Recursively list all CSV/XLSX items in a Girder folder."""
+    """Recursively list all CSV/XLSX items in a Girder folder.
+
+    .. deprecated::
+        Use list_recent_spreadsheets() for sensor polling. This function
+        performs a recursive folder crawl that scales poorly.
+    """
     items = client.get(
         "item",
         parameters={"folderId": folder_id, "limit": 100000},
@@ -22,6 +27,39 @@ def list_all_spreadsheet_items(client, folder_id):
     for subfolder in subfolders:
         result.extend(list_all_spreadsheet_items(client, subfolder["_id"]))
     return result
+
+
+def list_recent_spreadsheets(client, folder_id, limit=100):
+    """List recently created spreadsheet items in a Girder folder.
+
+    Unlike list_all_spreadsheet_items(), this does NOT recursively walk
+    subfolders. It queries items sorted by creation date (newest first)
+    and filters for CSV/XLSX extensions.
+
+    Parameters
+    ----------
+    client : GirderClient
+        Authenticated Girder client.
+    folder_id : str
+        The Girder folder ID to search.
+    limit : int
+        Maximum number of items to return.
+
+    Returns
+    -------
+    list[dict]
+        Girder item dicts for spreadsheet files, newest first.
+    """
+    items = client.get(
+        "item",
+        parameters={
+            "folderId": folder_id,
+            "sort": "created",
+            "sortdir": -1,
+            "limit": limit,
+        },
+    )
+    return [i for i in items if i["name"].endswith((".csv", ".xlsx", ".xls"))]
 
 
 def download_and_read(client, item_id, filename):

--- a/helix_dagster/sensors.py
+++ b/helix_dagster/sensors.py
@@ -4,22 +4,39 @@ from dagster import RunRequest, SensorEvaluationContext, sensor
 
 from helix_dagster.constants import HELIX_FOLDER_ID
 from helix_dagster.assets import process_helix_assets_job
-from helix_dagster.girder_io import list_all_spreadsheet_items
+from helix_dagster.girder_io import list_recent_spreadsheets
 from helix_dagster.resources import GirderConnection
 
 
 @sensor(job=process_helix_assets_job, minimum_interval_seconds=3600)
 def helix_folder_sensor(context: SensorEvaluationContext, girder: GirderConnection):
+    """Poll for new experiment log spreadsheets in the HELIX folder.
+
+    Uses a sorted recent-items query instead of recursive folder crawling.
+    Tracks seen item IDs in the cursor to avoid reprocessing.
+    """
     cursor_data = json.loads(context.cursor or '{"seen": []}')
     seen = set(cursor_data["seen"])
 
-    items = list_all_spreadsheet_items(girder, HELIX_FOLDER_ID)
+    items = list_recent_spreadsheets(girder, HELIX_FOLDER_ID, limit=100)
 
     new_seen = set(seen)
     requests = []
     for item in items:
         item_id = item["_id"]
         if item_id not in seen:
+            # Optionally check processing manifest
+            existing_meta = item.get("meta", {})
+            processing_status = existing_meta.get("processing_status", {})
+            if processing_status.get("status") == "completed_clean":
+                context.log.info(
+                    "Skipping %s — already processed cleanly on %s",
+                    item["name"],
+                    processing_status.get("last_processed", "unknown"),
+                )
+                new_seen.add(item_id)
+                continue
+
             requests.append(
                 RunRequest(
                     run_key=item_id,

--- a/tests/test_girder_io.py
+++ b/tests/test_girder_io.py
@@ -6,6 +6,7 @@ from helix_dagster.girder_io import (
     fetch_aimdl_datatypes,
     fetch_aimdl_datafiles,
     fetch_all_aimdl_datafiles,
+    list_recent_spreadsheets,
 )
 
 
@@ -20,6 +21,28 @@ def _make_item(name, igsn, data_type, item_id=None):
         "folderId": "folder123",
         "lowerName": name.lower(),
     }
+
+
+def test_list_recent_spreadsheets():
+    client = MagicMock()
+    client.get.return_value = [
+        {"name": "log_2025.csv", "_id": "c1", "created": "2025-03-01T00:00:00Z"},
+        {"name": "data.tdms", "_id": "c2", "created": "2025-03-01T00:00:00Z"},
+        {"name": "results.xlsx", "_id": "c3", "created": "2025-02-28T00:00:00Z"},
+    ]
+    result = list_recent_spreadsheets(client, "folder123", limit=50)
+    assert len(result) == 2  # only .csv and .xlsx, not .tdms
+    assert result[0]["name"] == "log_2025.csv"
+    assert result[1]["name"] == "results.xlsx"
+    client.get.assert_called_once_with(
+        "item",
+        parameters={
+            "folderId": "folder123",
+            "sort": "created",
+            "sortdir": -1,
+            "limit": 50,
+        },
+    )
 
 
 def test_fetch_datatypes():


### PR DESCRIPTION
## Summary

- Replaced recursive folder crawl in `helix_folder_sensor` with `list_recent_spreadsheets()` — a targeted query for the 100 most recent items sorted by creation date
- Integrated with the processing manifest: spreadsheets with `completed_clean` status are skipped
- Deprecated `list_all_spreadsheet_items()` with a doc comment

## Changes

- **girder_io.py**: Added `list_recent_spreadsheets()`, deprecated `list_all_spreadsheet_items()`
- **sensors.py**: Updated to use `list_recent_spreadsheets()` and check `meta.processing_status` before triggering reruns
- **tests/test_girder_io.py**: Added test for new function
- **CLAUDE.md**: Updated workflow description

Closes #18

## Test plan

- [x] New `test_list_recent_spreadsheets` passes
- [x] All existing tests still pass (2 pre-existing failures in `test_processing_manifest_*` unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)