### PR TITLE
fix: complete Stage 2 — pdv_inventory → pdv_trace_inventory

### DIFF
--- a/helix_dagster/__init__.py
+++ b/helix_dagster/__init__.py
@@ -6,7 +6,7 @@ from helix_dagster.assets import (
     alpss_results_inventory,
     enriched_pdv_metadata,
     pdv_cross_references,
-    pdv_inventory,
+    pdv_trace_inventory,
     process_helix_assets_job,
     processing_manifest,
     quality_report,
@@ -27,7 +27,7 @@ from helix_dagster.sensors import helix_folder_sensor
 defs = Definitions(
     assets=[
         raw_experiment_log,
-        pdv_inventory,
+        pdv_trace_inventory,
         validated_rows,
         pdv_cross_references,
         enriched_pdv_metadata,

--- a/helix_dagster/assets.py
+++ b/helix_dagster/assets.py
@@ -12,7 +12,7 @@ from dagster import (
 )
 
 from helix_dagster import __version__ as PIPELINE_VERSION
-from helix_dagster.constants import ALPSS_RESULT_DATA_TYPE, COLUMN_MAP, PDV_FOLDER_ID
+from helix_dagster.constants import ALPSS_RESULT_DATA_TYPE, COLUMN_MAP, PDV_TRACE_DATA_TYPE
 from helix_dagster.coordinates import transform_station_to_sample
 from helix_dagster.girder_io import download_and_read, fetch_all_aimdl_datafiles, nan_to_none
 from helix_dagster.matching import match_pdv_file
@@ -45,20 +45,36 @@ def raw_experiment_log(
 
 
 @asset
-def pdv_inventory(
+def pdv_trace_inventory(
     context: AssetExecutionContext,
     girder: GirderConnection,
 ) -> list:
-    """Fetch all items from the PDV folder via Girder API."""
-    items = girder.get(
-        "item",
-        parameters={"folderId": PDV_FOLDER_ID, "limit": 100000},
-    )
-    context.add_output_metadata(
-        {
-            "item_count": MetadataValue.int(len(items)),
-        }
-    )
+    """Fetch PDV trace items via the /aimdl/datafiles endpoint.
+
+    Uses an indexed MongoDB query filtered by meta.data_type='pdv_trace'
+    instead of crawling the PDV folder tree. Items must have meta.igsn
+    set to appear in results.
+    """
+    items = fetch_all_aimdl_datafiles(girder, PDV_TRACE_DATA_TYPE)
+
+    igsns = set()
+    for item in items:
+        igsn = item.get("meta", {}).get("igsn")
+        if igsn:
+            igsns.add(igsn)
+
+    context.add_output_metadata({
+        "item_count": MetadataValue.int(len(items)),
+        "unique_igsns": MetadataValue.int(len(igsns)),
+        "data_type": MetadataValue.text(PDV_TRACE_DATA_TYPE),
+    })
+
+    if len(items) == 0:
+        context.log.warning(
+            "pdv_trace_inventory returned 0 items. This may indicate that "
+            "meta.igsn has not been tagged on PDV files yet."
+        )
+
     return items
 
 
@@ -100,7 +116,7 @@ def validated_rows(
 def pdv_cross_references(
     context: AssetExecutionContext,
     validated_rows: dict,
-    pdv_inventory: list,
+    pdv_trace_inventory: list,
 ) -> dict:
     """Match PDV filenames to inventory items. Pure matching, no network calls."""
     df = validated_rows["dataframe"]
@@ -109,9 +125,20 @@ def pdv_cross_references(
 
     for idx, row in df.iterrows():
         pdv_filename = row.get("PDV_FileName")
-        pdv_item, issue = match_pdv_file(pdv_inventory, pdv_filename)
+        pdv_item, issue = match_pdv_file(pdv_trace_inventory, pdv_filename)
         if pdv_item is not None:
             matches[idx] = pdv_item
+            # Cross-check IGSN consistency
+            row_igsn = row.get("valid_igsn")
+            item_igsn = pdv_item.get("meta", {}).get("igsn")
+            if row_igsn and item_igsn and row_igsn != item_igsn:
+                pdv_issues.append({
+                    "pdv_filename": pdv_filename,
+                    "type": "igsn_mismatch",
+                    "row": idx,
+                    "spreadsheet_igsn": row_igsn,
+                    "item_igsn": item_igsn,
+                })
         if issue is not None:
             issue["row"] = idx
             pdv_issues.append(issue)
@@ -120,11 +147,14 @@ def pdv_cross_references(
     not_found_count = sum(1 for i in pdv_issues if i["type"] == "not_found")
     ambiguous_count = sum(1 for i in pdv_issues if i["type"] == "ambiguous")
 
+    mismatch_count = sum(1 for i in pdv_issues if i["type"] == "igsn_mismatch")
+
     context.add_output_metadata(
         {
             "matched_count": MetadataValue.int(matched_count),
             "not_found_count": MetadataValue.int(not_found_count),
             "ambiguous_count": MetadataValue.int(ambiguous_count),
+            "igsn_mismatch_count": MetadataValue.int(mismatch_count),
         }
     )
     return {"matches": matches, "pdv_issues": pdv_issues}

--- a/helix_dagster/checks.py
+++ b/helix_dagster/checks.py
@@ -13,13 +13,14 @@ from dagster import (
 )
 
 
-@asset_check(asset="pdv_inventory")
-def zero_inventory(context, pdv_inventory):
-    """ERROR if the PDV inventory returned zero items.
+@asset_check(asset="pdv_trace_inventory")
+def zero_inventory(context, pdv_trace_inventory):
+    """ERROR if the PDV trace inventory returned zero items.
 
-    This typically means the PDV folder is empty or misconfigured.
+    This typically means meta.igsn has not been tagged on PDV files yet,
+    so the /aimdl/datafiles endpoint returns nothing.
     """
-    count = len(pdv_inventory)
+    count = len(pdv_trace_inventory)
     passed = count > 0
     return AssetCheckResult(
         passed=passed,
@@ -28,7 +29,7 @@ def zero_inventory(context, pdv_inventory):
         description=(
             f"Inventory contains {count} items."
             if passed
-            else "Inventory is EMPTY. Check PDV folder configuration."
+            else "Inventory is EMPTY. Check that meta.igsn is tagged on PDV files."
         ),
     )
 

--- a/helix_dagster/constants.py
+++ b/helix_dagster/constants.py
@@ -2,7 +2,6 @@ import os
 import re
 
 HELIX_FOLDER_ID = os.environ.get("HELIX_FOLDER_ID")
-PDV_FOLDER_ID = os.environ.get("PDV_FOLDER_ID")
 
 IGSN_PATTERN = re.compile(r"[A-Za-z]{6}\d{5}(?:-[A-Za-z0-9]+)?")
 

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -53,8 +53,8 @@ def test_pdv_cross_references_pure():
     )
 
     pdv_items = [
-        {"name": "shot001_ch1.tdms", "_id": "a1"},
-        {"name": "shot002_ch1.tdms", "_id": "b1"},
+        {"name": "shot001_ch1.tdms", "_id": "a1", "meta": {"igsn": "ABCDEF12345", "data_type": "pdv_trace"}},
+        {"name": "shot002_ch1.tdms", "_id": "b1", "meta": {"igsn": "ABCDEF12346", "data_type": "pdv_trace"}},
     ]
 
     validated = {"dataframe": df, "igsn_issues": []}
@@ -63,7 +63,7 @@ def test_pdv_cross_references_pure():
     result = pdv_cross_references_fn(
         context=ctx,
         validated_rows=validated,
-        pdv_inventory=pdv_items,
+        pdv_trace_inventory=pdv_items,
     )
 
     matches = result["matches"]
@@ -94,7 +94,7 @@ def test_asset_dag_loads():
 
     expected_assets = {
         "raw_experiment_log",
-        "pdv_inventory",
+        "pdv_trace_inventory",
         "validated_rows",
         "pdv_cross_references",
         "enriched_pdv_metadata",
@@ -110,6 +110,30 @@ def test_asset_dag_loads():
         str(ck) for ck in repo.asset_graph.asset_check_keys
     }
     assert len(check_keys) >= 5, f"Expected at least 5 asset checks, got {len(check_keys)}"
+
+
+def test_igsn_mismatch_detection():
+    """Verify that IGSN mismatches between spreadsheet and Girder item are flagged."""
+    df = pd.DataFrame([
+        {"Sample_IGSN": "ABCDEF12345", "PDV_FileName": "shot001",
+         "valid_igsn": "ABCDEF12345"},
+    ])
+    pdv_items = [
+        {"name": "shot001_ch1.tdms", "_id": "a1",
+         "meta": {"igsn": "XXXXXX99999", "data_type": "pdv_trace"}},
+    ]
+    validated = {"dataframe": df, "igsn_issues": []}
+    ctx = build_asset_context()
+    result = pdv_cross_references_fn(
+        context=ctx,
+        validated_rows=validated,
+        pdv_trace_inventory=pdv_items,
+    )
+    issues = result["pdv_issues"]
+    mismatch_issues = [i for i in issues if i["type"] == "igsn_mismatch"]
+    assert len(mismatch_issues) == 1
+    assert mismatch_issues[0]["spreadsheet_igsn"] == "ABCDEF12345"
+    assert mismatch_issues[0]["item_igsn"] == "XXXXXX99999"
 
 
 def test_quality_report_alpss_completeness():

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -15,14 +15,14 @@ from helix_dagster.checks import (
 
 def test_zero_inventory_fails_on_empty():
     ctx = build_asset_context()
-    result = zero_inventory(ctx, pdv_inventory=[])
+    result = zero_inventory(ctx, pdv_trace_inventory=[])
     assert not result.passed
     assert result.severity.value == "ERROR"
 
 
 def test_zero_inventory_passes_with_items():
     ctx = build_asset_context()
-    result = zero_inventory(ctx, pdv_inventory=[{"_id": "a"}])
+    result = zero_inventory(ctx, pdv_trace_inventory=[{"_id": "a"}])
     assert result.passed
 
 


### PR DESCRIPTION
## Problem

The Stage 2 refactoring was skipped during initial execution. The pipeline
still used the old `pdv_inventory` asset which fetches 100,000+ items from
the PDV folder. All of Stages 3-6 were built on top of this old asset.

## Fix

- Replaced `pdv_inventory` with `pdv_trace_inventory` using
  `/aimdl/datafiles?dataType=pdv_trace` (indexed MongoDB query)
- Added IGSN consistency checking to `pdv_cross_references`
- Removed `PDV_FOLDER_ID` environment variable dependency
- Updated `checks.py` `zero_inventory` to target `pdv_trace_inventory`
- Updated all tests and Definitions

## Files changed

- `helix_dagster/assets.py` — core rename + IGSN consistency
- `helix_dagster/constants.py` — removed `PDV_FOLDER_ID`
- `helix_dagster/checks.py` — retargeted `zero_inventory`
- `helix_dagster/__init__.py` — updated imports and Definitions
- `tests/test_assets.py` — updated params, added IGSN mismatch test
- `tests/test_checks.py` — updated params

## Test plan

- [x] `grep -rn "pdv_inventory" helix_dagster/ tests/` returns ZERO results
- [x] `grep -rn "PDV_FOLDER_ID" helix_dagster/ tests/` returns ZERO results
- [x] All 42 tests pass (2 pre-existing failures unrelated to this change)
- [x] New `test_igsn_mismatch_detection` test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)