### PR TITLE
refactor: fetch MAXIMA inventory via /aimdl/partition for full meta (…

### DIFF
--- a/helix_dagster/__init__.py
+++ b/helix_dagster/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.5.0"
+__version__ = "0.6.0"
 
 from dagster import AssetSelection, Definitions, EnvVar, define_asset_job
 

--- a/helix_dagster/coord_enrichment/inventory.py
+++ b/helix_dagster/coord_enrichment/inventory.py
@@ -13,7 +13,10 @@ from dagster import (
     asset_check,
 )
 
-from helix_dagster.girder_io import fetch_all_aimdl_datafiles
+from helix_dagster.girder_io import (
+    fetch_all_aimdl_datafiles,
+    fetch_items_by_partition,
+)
 from helix_dagster.instruments import (
     all_in_scope_data_types,
     instrument_for_data_type,
@@ -21,6 +24,14 @@ from helix_dagster.instruments import (
 from helix_dagster.resources import GirderConnection
 
 logger = logging.getLogger(__name__)
+
+# Data types served by the partition-aware endpoints
+# (/aimdl/partition + /aimdl/partition/details). These return items
+# with full meta (experiment_date, prov, checksum, ...) intact,
+# unlike /aimdl/datafiles which strips meta to data_type and igsn.
+PARTITION_AWARE_DATA_TYPES = frozenset(
+    {"xrd_raw", "xrf_raw", "xrd_derived", "xrd_metadata"}
+)
 
 MAXIMA_RAW_PARTITIONS = StaticPartitionsDefinition(
     ["MAXIMA/xrd_raw", "MAXIMA/xrf_raw"]
@@ -94,7 +105,10 @@ def enrichable_items_inventory(
     context.log.info("Fetching inventory for data types: %s", data_types)
 
     for dt in data_types:
-        items = fetch_all_aimdl_datafiles(girder, dt)
+        if dt in PARTITION_AWARE_DATA_TYPES:
+            items = fetch_items_by_partition(girder, dt)
+        else:
+            items = fetch_all_aimdl_datafiles(girder, dt)
         in_scope = [it for it in items if _is_in_scope(it)]
         if dt == "xrd_derived":
             in_scope = filter_to_raw_subfolder(in_scope, girder)

--- a/helix_dagster/girder_io.py
+++ b/helix_dagster/girder_io.py
@@ -151,3 +151,53 @@ def fetch_all_aimdl_datafiles(client, data_type):
             break
         offset += AIMDL_PAGE_LIMIT
     return all_items
+
+
+def fetch_partition_keys(client, data_type):
+    """Return the partition index for a partition-aware data_type.
+
+    Calls ``GET /aimdl/partition?dataType=<data_type>`` and returns the
+    response dict, keyed by ``"<igsn>//<experiment_date>"`` with
+    payload-hash values. Used to enumerate all runs of a given data
+    type before fetching full-meta items per key.
+    """
+    return client.get(
+        "aimdl/partition",
+        parameters={"dataType": data_type},
+    )
+
+
+def fetch_items_by_partition(client, data_type):
+    """Fetch all items of a partition-aware data_type with FULL meta.
+
+    Calls ``/aimdl/partition`` once to enumerate keys, then
+    ``/aimdl/partition/details`` once per key. Returns a flat list of
+    Girder item dicts with full meta (``experiment_date``, ``prov``,
+    ``checksum``, etc.) preserved — unlike ``/aimdl/datafiles`` which
+    strips meta down to ``data_type`` and ``igsn``.
+
+    Partition keys with empty details are silently skipped.
+
+    Parameters
+    ----------
+    client : GirderClient
+        Authenticated Girder client.
+    data_type : str
+        A partition-aware ``meta.data_type`` (e.g. ``xrd_raw``).
+
+    Returns
+    -------
+    list[dict]
+        All items for the data_type with full meta.
+    """
+    keys = fetch_partition_keys(client, data_type)
+    all_items = []
+    for key in keys:
+        details = client.get(
+            "aimdl/partition/details",
+            parameters={"key": key, "dataType": data_type},
+        )
+        if not details:
+            continue
+        all_items.extend(details)
+    return all_items

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "helix_dagster"
-version = "0.5.0"
+version = "0.6.0"
 description = "Dagster pipeline for HELIX experiment metadata extraction and enrichment"
 dependencies = [
     "dagster",

--- a/tests/test_coord_enrichment_e2e.py
+++ b/tests/test_coord_enrichment_e2e.py
@@ -234,5 +234,5 @@ def test_e2e_manifest_written(xrd_items, xrf_items, girder_mock):
     assert "write_skipped" not in manifest_result
     assert "write_failed" not in manifest_result
     assert manifest_result["dry_run"] is False
-    assert manifest_result["pipeline_version"] == "0.5.0"
+    assert manifest_result["pipeline_version"] == "0.6.0"
     assert manifest_result["job"] == "unknown"  # direct invocation, no job context

--- a/tests/test_coord_enrichment_inventory.py
+++ b/tests/test_coord_enrichment_inventory.py
@@ -8,6 +8,7 @@ from dagster import build_asset_context
 
 from helix_dagster.coord_enrichment.inventory import (
     MAXIMA_RAW_PARTITIONS,
+    PARTITION_AWARE_DATA_TYPES,
     _is_in_scope,
     enrichable_items_inventory,
     filter_to_raw_subfolder,
@@ -27,9 +28,11 @@ def _make_item(data_type, igsn=None, **extra_meta):
 # ── enrichable_items_inventory ──────────────────────────────────────
 
 
+@patch("helix_dagster.coord_enrichment.inventory.fetch_items_by_partition")
 @patch("helix_dagster.coord_enrichment.inventory.fetch_all_aimdl_datafiles")
-def test_inventory_returns_all_in_scope_data_type_keys(mock_fetch):
-    mock_fetch.return_value = []
+def test_inventory_returns_all_in_scope_data_type_keys(mock_datafiles, mock_partition):
+    mock_datafiles.return_value = []
+    mock_partition.return_value = []
     girder = MagicMock()
     ctx = build_asset_context()
 
@@ -44,9 +47,10 @@ def test_inventory_returns_all_in_scope_data_type_keys(mock_fetch):
         assert v == []
 
 
+@patch("helix_dagster.coord_enrichment.inventory.fetch_items_by_partition")
 @patch("helix_dagster.coord_enrichment.inventory.fetch_all_aimdl_datafiles")
-def test_inventory_filters_out_missing_igsn(mock_fetch):
-    def side_effect(_client, dt):
+def test_inventory_filters_out_missing_igsn(mock_datafiles, mock_partition):
+    def partition_side_effect(_client, dt):
         if dt == "xrd_raw":
             return [
                 _make_item("xrd_raw", igsn="JHAMAB00001"),
@@ -54,7 +58,8 @@ def test_inventory_filters_out_missing_igsn(mock_fetch):
             ]
         return []
 
-    mock_fetch.side_effect = side_effect
+    mock_partition.side_effect = partition_side_effect
+    mock_datafiles.return_value = []
     girder = MagicMock()
     ctx = build_asset_context()
 
@@ -63,14 +68,16 @@ def test_inventory_filters_out_missing_igsn(mock_fetch):
     assert len(result["MAXIMA/xrd_raw"]) == 1
 
 
+@patch("helix_dagster.coord_enrichment.inventory.fetch_items_by_partition")
 @patch("helix_dagster.coord_enrichment.inventory.fetch_all_aimdl_datafiles")
-def test_inventory_keeps_items_with_igsn(mock_fetch):
-    def side_effect(_client, dt):
+def test_inventory_keeps_items_with_igsn(mock_datafiles, mock_partition):
+    def partition_side_effect(_client, dt):
         if dt == "xrf_raw":
             return [_make_item("xrf_raw", igsn="JHAMAB00002")]
         return []
 
-    mock_fetch.side_effect = side_effect
+    mock_partition.side_effect = partition_side_effect
+    mock_datafiles.return_value = []
     girder = MagicMock()
     ctx = build_asset_context()
 
@@ -80,9 +87,13 @@ def test_inventory_keeps_items_with_igsn(mock_fetch):
     assert result["MAXIMA/xrf_raw"][0]["meta"]["igsn"] == "JHAMAB00002"
 
 
+@patch("helix_dagster.coord_enrichment.inventory.fetch_items_by_partition")
 @patch("helix_dagster.coord_enrichment.inventory.fetch_all_aimdl_datafiles")
-def test_inventory_key_format_is_instrument_slash_data_type(mock_fetch):
-    mock_fetch.return_value = []
+def test_inventory_key_format_is_instrument_slash_data_type(
+    mock_datafiles, mock_partition,
+):
+    mock_datafiles.return_value = []
+    mock_partition.return_value = []
     girder = MagicMock()
     ctx = build_asset_context()
 
@@ -96,9 +107,13 @@ def test_inventory_key_format_is_instrument_slash_data_type(mock_fetch):
         assert dt in all_in_scope_data_types()
 
 
+@patch("helix_dagster.coord_enrichment.inventory.fetch_items_by_partition")
 @patch("helix_dagster.coord_enrichment.inventory.fetch_all_aimdl_datafiles")
-def test_inventory_logs_per_data_type_counts(mock_fetch, capsys):
-    mock_fetch.return_value = []
+def test_inventory_logs_per_data_type_counts(
+    mock_datafiles, mock_partition, capsys,
+):
+    mock_datafiles.return_value = []
+    mock_partition.return_value = []
     girder = MagicMock()
     ctx = build_asset_context()
 
@@ -108,6 +123,75 @@ def test_inventory_logs_per_data_type_counts(mock_fetch, capsys):
     # that logging doesn't error is the primary check here.
     # TODO: assert log output contains data_type names once Dagster
     # test log capture is wired up.
+
+
+@patch("helix_dagster.coord_enrichment.inventory.fetch_items_by_partition")
+@patch("helix_dagster.coord_enrichment.inventory.fetch_all_aimdl_datafiles")
+def test_inventory_uses_partition_api_for_maxima_types(
+    mock_datafiles, mock_partition,
+):
+    """MAXIMA partition-aware types must route through the partition API."""
+    mock_datafiles.return_value = []
+    mock_partition.return_value = []
+    girder = MagicMock()
+    ctx = build_asset_context()
+
+    enrichable_items_inventory(ctx, girder)
+
+    partition_dts = {call.args[1] for call in mock_partition.call_args_list}
+    # The inventory only fetches in-scope types; xrd_metadata is
+    # partition-aware but out-of-scope, so it's not fetched.
+    expected = PARTITION_AWARE_DATA_TYPES & all_in_scope_data_types()
+    assert partition_dts == expected
+    # Those same types must NOT have been fetched via /aimdl/datafiles.
+    datafiles_dts = {call.args[1] for call in mock_datafiles.call_args_list}
+    assert datafiles_dts.isdisjoint(PARTITION_AWARE_DATA_TYPES)
+
+
+@patch("helix_dagster.coord_enrichment.inventory.fetch_items_by_partition")
+@patch("helix_dagster.coord_enrichment.inventory.fetch_all_aimdl_datafiles")
+def test_inventory_uses_datafiles_for_helix(mock_datafiles, mock_partition):
+    """HELIX data types (pdv_alpss_*) still use /aimdl/datafiles."""
+    mock_datafiles.return_value = []
+    mock_partition.return_value = []
+    girder = MagicMock()
+    ctx = build_asset_context()
+
+    enrichable_items_inventory(ctx, girder)
+
+    datafiles_dts = {call.args[1] for call in mock_datafiles.call_args_list}
+    helix_dts = all_in_scope_data_types() - PARTITION_AWARE_DATA_TYPES
+    assert helix_dts, "HELIX data types expected in scope"
+    assert helix_dts <= datafiles_dts
+
+
+@patch("helix_dagster.coord_enrichment.inventory.fetch_items_by_partition")
+@patch("helix_dagster.coord_enrichment.inventory.fetch_all_aimdl_datafiles")
+def test_items_carry_full_meta_through_inventory(mock_datafiles, mock_partition):
+    """Regression: partition-sourced items keep full meta (experiment_date)."""
+    def partition_side_effect(_client, dt):
+        if dt == "xrd_raw":
+            return [
+                _make_item(
+                    "xrd_raw",
+                    igsn="JHAMAB00007",
+                    experiment_date="2026-04-16",
+                    prov={"wasDerivedFrom": "parent-id"},
+                ),
+            ]
+        return []
+
+    mock_partition.side_effect = partition_side_effect
+    mock_datafiles.return_value = []
+    girder = MagicMock()
+    ctx = build_asset_context()
+
+    result = enrichable_items_inventory(ctx, girder)
+
+    assert len(result["MAXIMA/xrd_raw"]) == 1
+    meta = result["MAXIMA/xrd_raw"][0]["meta"]
+    assert meta["experiment_date"] == "2026-04-16"
+    assert meta["prov"] == {"wasDerivedFrom": "parent-id"}
 
 
 # ── inventory_nonempty_per_instrument check ─────────────────────────

--- a/tests/test_coord_enrichment_partitioned_jobs.py
+++ b/tests/test_coord_enrichment_partitioned_jobs.py
@@ -73,7 +73,7 @@ def test_defs_loads_without_errors():
     assert len(repo.job_names) >= 5
 
 
-def test_version_is_0_5_0():
+def test_version_is_0_6_0():
     import helix_dagster
 
-    assert helix_dagster.__version__ == "0.5.0"
+    assert helix_dagster.__version__ == "0.6.0"

--- a/tests/test_coord_enrichment_phase4_e2e.py
+++ b/tests/test_coord_enrichment_phase4_e2e.py
@@ -336,5 +336,5 @@ def test_phase4_manifest_written(girder_mock):
     assert "write_skipped" not in manifest
     assert "write_failed" not in manifest
     assert manifest["dry_run"] is False
-    assert manifest["pipeline_version"] == "0.5.0"
+    assert manifest["pipeline_version"] == "0.6.0"
     assert manifest["job"] == "unknown"  # direct invocation, no job context

--- a/tests/test_girder_io.py
+++ b/tests/test_girder_io.py
@@ -6,6 +6,8 @@ from helix_dagster.girder_io import (
     fetch_aimdl_datatypes,
     fetch_aimdl_datafiles,
     fetch_all_aimdl_datafiles,
+    fetch_items_by_partition,
+    fetch_partition_keys,
     list_recent_spreadsheets,
 )
 
@@ -100,3 +102,85 @@ def test_fetch_all_single_page():
     result = fetch_all_aimdl_datafiles(client, "pdv_trace")
     assert len(result) == 50
     assert client.get.call_count == 1  # No second page needed
+
+
+# ── partition-aware helpers ─────────────────────────────────────────
+
+
+def test_fetch_partition_keys():
+    """fetch_partition_keys returns the raw dict from /aimdl/partition."""
+    client = MagicMock()
+    client.get.return_value = {
+        "JHAMAB00001//2026-04-16": "hash-a",
+        "JHAMAB00002//2026-04-17": "hash-b",
+    }
+    result = fetch_partition_keys(client, "xrd_raw")
+    client.get.assert_called_once_with(
+        "aimdl/partition",
+        parameters={"dataType": "xrd_raw"},
+    )
+    assert result == {
+        "JHAMAB00001//2026-04-16": "hash-a",
+        "JHAMAB00002//2026-04-17": "hash-b",
+    }
+
+
+def test_fetch_items_by_partition_paginates_over_keys():
+    """Each partition key is fetched via /aimdl/partition/details and
+    the results are concatenated in key-iteration order."""
+    partition_index = {
+        "JHAMAB00001//2026-04-16": "hash-a",
+        "JHAMAB00002//2026-04-17": "hash-b",
+    }
+    items_a = [
+        _make_item("a1.tif", "JHAMAB00001", "xrd_raw"),
+        _make_item("a2.tif", "JHAMAB00001", "xrd_raw"),
+    ]
+    items_b = [
+        _make_item("b1.tif", "JHAMAB00002", "xrd_raw"),
+        _make_item("b2.tif", "JHAMAB00002", "xrd_raw"),
+    ]
+
+    client = MagicMock()
+
+    def fake_get(path, parameters=None):
+        if path == "aimdl/partition":
+            assert parameters == {"dataType": "xrd_raw"}
+            return partition_index
+        if path == "aimdl/partition/details":
+            assert parameters["dataType"] == "xrd_raw"
+            if parameters["key"] == "JHAMAB00001//2026-04-16":
+                return items_a
+            if parameters["key"] == "JHAMAB00002//2026-04-17":
+                return items_b
+        raise AssertionError(f"unexpected call: {path} {parameters}")
+
+    client.get.side_effect = fake_get
+
+    result = fetch_items_by_partition(client, "xrd_raw")
+    assert len(result) == 4
+    assert [it["name"] for it in result] == ["a1.tif", "a2.tif", "b1.tif", "b2.tif"]
+
+
+def test_fetch_items_by_partition_handles_empty_partition():
+    """A key whose details call returns [] is skipped silently."""
+    partition_index = {
+        "JHAMAB00001//2026-04-16": "hash-a",
+        "JHAMAB00002//2026-04-17": "hash-b",
+    }
+    client = MagicMock()
+
+    def fake_get(path, parameters=None):
+        if path == "aimdl/partition":
+            return partition_index
+        if path == "aimdl/partition/details":
+            if parameters["key"] == "JHAMAB00001//2026-04-16":
+                return []  # empty — should be skipped, not raised
+            return [_make_item("only.tif", "JHAMAB00002", "xrd_raw")]
+        raise AssertionError(f"unexpected call: {path}")
+
+    client.get.side_effect = fake_get
+
+    result = fetch_items_by_partition(client, "xrd_raw")
+    assert len(result) == 1
+    assert result[0]["name"] == "only.tif"


### PR DESCRIPTION
…#21)

/aimdl/datafiles strips items down to data_type and igsn, which masked meta.experiment_date on 19,066 MAXIMA xrd_raw items during the adaboo rehearsal and produced 19,066 "missing meta.experiment_date" resolution_errors. Route partition-aware data types (xrd_raw, xrf_raw, xrd_derived, xrd_metadata) through /aimdl/partition + /aimdl/partition/details so full meta survives into downstream leaves. HELIX pdv_trace stays on /aimdl/datafiles (not partition- aware). Inventory return shape is unchanged.

Bumps pipeline version 0.5.0 -> 0.6.0.