### PR TITLE
refactor: assign group_name to every Dagster asset (#28)

### DIFF
--- a/aimdl_coord_enrichment/assets.py
+++ b/aimdl_coord_enrichment/assets.py
@@ -30,7 +30,7 @@ class ExperimentLogConfig(Config):
     filename: str
 
 
-@asset
+@asset(group_name="helix_spreadsheet")
 def experiment_log_source(
     context: AssetExecutionContext,
     config: ExperimentLogConfig,
@@ -53,7 +53,7 @@ def experiment_log_source(
     return source
 
 
-@asset
+@asset(group_name="helix_spreadsheet")
 def raw_experiment_log(
     context: AssetExecutionContext,
     experiment_log_source: dict,
@@ -74,7 +74,7 @@ def raw_experiment_log(
     return df
 
 
-@asset
+@asset(group_name="helix_spreadsheet")
 def pdv_trace_inventory(
     context: AssetExecutionContext,
     girder: GirderConnection,
@@ -108,7 +108,7 @@ def pdv_trace_inventory(
     return items
 
 
-@asset
+@asset(group_name="helix_spreadsheet")
 def validated_rows(
     context: AssetExecutionContext,
     raw_experiment_log: pd.DataFrame,
@@ -142,7 +142,7 @@ def validated_rows(
     return {"dataframe": df, "igsn_issues": igsn_issues}
 
 
-@asset
+@asset(group_name="helix_spreadsheet")
 def pdv_cross_references(
     context: AssetExecutionContext,
     validated_rows: dict,
@@ -190,7 +190,7 @@ def pdv_cross_references(
     return {"matches": matches, "pdv_issues": pdv_issues}
 
 
-@asset
+@asset(group_name="helix_spreadsheet")
 def enriched_pdv_metadata(
     context: AssetExecutionContext,
     experiment_log_source: dict,
@@ -336,7 +336,7 @@ def enriched_pdv_metadata(
     }
 
 
-@asset
+@asset(group_name="helix_spreadsheet")
 def alpss_results_inventory(
     context: AssetExecutionContext,
     girder: GirderConnection,
@@ -362,7 +362,7 @@ def alpss_results_inventory(
     return items
 
 
-@asset
+@asset(group_name="helix_spreadsheet")
 def quality_report(
     context: AssetExecutionContext,
     validated_rows: dict,
@@ -426,7 +426,7 @@ def quality_report(
     return report
 
 
-@asset
+@asset(group_name="helix_spreadsheet")
 def processing_manifest(
     context: AssetExecutionContext,
     experiment_log_source: dict,

--- a/aimdl_coord_enrichment/coord_enrichment/config_snapshot.py
+++ b/aimdl_coord_enrichment/coord_enrichment/config_snapshot.py
@@ -24,7 +24,7 @@ class CoordTransformSnapshot:
     versions_by_instrument: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
 
 
-@asset
+@asset(group_name="coord_enrichment_core")
 def coord_transform_config_snapshot(
     context: AssetExecutionContext,
 ) -> CoordTransformSnapshot:

--- a/aimdl_coord_enrichment/coord_enrichment/enrichment_leaves.py
+++ b/aimdl_coord_enrichment/coord_enrichment/enrichment_leaves.py
@@ -137,6 +137,7 @@ def _fetch_instructions_for_run(
 
 
 @asset(
+    group_name="maxima_raw",
     partitions_def=MAXIMA_RAW_PARTITIONS,
 )
 def enriched_maxima_raw(

--- a/aimdl_coord_enrichment/coord_enrichment/helix_alpss_leaf.py
+++ b/aimdl_coord_enrichment/coord_enrichment/helix_alpss_leaf.py
@@ -47,6 +47,7 @@ HELIX_ALPSS_PARTITIONS = StaticPartitionsDefinition(
 
 
 @asset(
+    group_name="helix_alpss",
     partitions_def=HELIX_ALPSS_PARTITIONS,
     deps=["helix_alpss_provenance_tagged"],
 )

--- a/aimdl_coord_enrichment/coord_enrichment/inventory.py
+++ b/aimdl_coord_enrichment/coord_enrichment/inventory.py
@@ -101,7 +101,7 @@ def _is_in_scope(item: dict) -> bool:
     return True
 
 
-@asset
+@asset(group_name="coord_enrichment_core")
 def enrichable_items_inventory(
     context: AssetExecutionContext,
     girder: GirderConnection,

--- a/aimdl_coord_enrichment/coord_enrichment/manifest.py
+++ b/aimdl_coord_enrichment/coord_enrichment/manifest.py
@@ -11,7 +11,7 @@ from aimdl_coord_enrichment.coord_enrichment.config import CoordEnrichmentConfig
 from aimdl_coord_enrichment.resources import GirderConnection
 
 
-@asset
+@asset(group_name="coord_enrichment_reporting")
 def coord_enrichment_manifest(
     context: AssetExecutionContext,
     config: CoordEnrichmentConfig,

--- a/aimdl_coord_enrichment/coord_enrichment/maxima_derived_leaf.py
+++ b/aimdl_coord_enrichment/coord_enrichment/maxima_derived_leaf.py
@@ -47,6 +47,7 @@ MAXIMA_DERIVED_PARTITIONS = StaticPartitionsDefinition(
 
 
 @asset(
+    group_name="maxima_derived",
     partitions_def=MAXIMA_DERIVED_PARTITIONS,
     deps=[
         AssetDep(

--- a/aimdl_coord_enrichment/coord_enrichment/pdv_observer.py
+++ b/aimdl_coord_enrichment/coord_enrichment/pdv_observer.py
@@ -19,7 +19,7 @@ from aimdl_coord_enrichment.resources import GirderConnection
 PDV_COVERAGE_WARN_THRESHOLD = 0.5
 
 
-@asset
+@asset(group_name="coord_enrichment_reporting")
 def helix_pdv_coverage_observer(
     context: AssetExecutionContext,
     girder: GirderConnection,

--- a/aimdl_coord_enrichment/coord_enrichment/provenance_tagging.py
+++ b/aimdl_coord_enrichment/coord_enrichment/provenance_tagging.py
@@ -108,7 +108,7 @@ def _apply_decision(
         write_ops.append(op)
 
 
-@asset
+@asset(group_name="helix_alpss")
 def helix_alpss_provenance_tagged(
     context: AssetExecutionContext,
     config: CoordEnrichmentConfig,

--- a/aimdl_coord_enrichment/coord_enrichment/report.py
+++ b/aimdl_coord_enrichment/coord_enrichment/report.py
@@ -110,6 +110,7 @@ def _read_leaf_partitions(
 
 
 @asset(
+    group_name="coord_enrichment_reporting",
     deps=[
         AssetDep("enriched_maxima_raw", partition_mapping=AllPartitionMapping()),
         AssetDep("enriched_helix_alpss", partition_mapping=AllPartitionMapping()),

--- a/tests/test_asset_groups.py
+++ b/tests/test_asset_groups.py
@@ -1,0 +1,75 @@
+"""Convention guard for Dagster asset `group_name` assignments.
+
+See .claude/prompts/asset-groups/ISSUE.md (tracking #28) for the
+rationale. Group names separate the two DAGs by instrument and role
+in the Dagster UI. This test locks the assignment so future edits
+can't silently drop assets back into the implicit `default` group.
+
+Groups are resolved from the loaded `Definitions`
+(`aimdl_coord_enrichment.defs`), mirroring the convention-enforcement
+style of `tests/test_annotations_rule.py`.
+"""
+
+from aimdl_coord_enrichment import defs
+
+# Asset key -> expected group_name. 18 assets across 6 groups.
+EXPECTED_GROUPS = {
+    "experiment_log_source": "helix_spreadsheet",
+    "raw_experiment_log": "helix_spreadsheet",
+    "pdv_trace_inventory": "helix_spreadsheet",
+    "validated_rows": "helix_spreadsheet",
+    "pdv_cross_references": "helix_spreadsheet",
+    "enriched_pdv_metadata": "helix_spreadsheet",
+    "alpss_results_inventory": "helix_spreadsheet",
+    "quality_report": "helix_spreadsheet",
+    "processing_manifest": "helix_spreadsheet",
+    "helix_alpss_provenance_tagged": "helix_alpss",
+    "enriched_helix_alpss": "helix_alpss",
+    "enriched_maxima_raw": "maxima_raw",
+    "enriched_maxima_derived": "maxima_derived",
+    "coord_transform_config_snapshot": "coord_enrichment_core",
+    "enrichable_items_inventory": "coord_enrichment_core",
+    "coord_enrichment_report": "coord_enrichment_reporting",
+    "coord_enrichment_manifest": "coord_enrichment_reporting",
+    "helix_pdv_coverage_observer": "coord_enrichment_reporting",
+}
+
+EXPECTED_COUNTS = {
+    "helix_spreadsheet": 9,
+    "helix_alpss": 2,
+    "maxima_raw": 1,
+    "maxima_derived": 1,
+    "coord_enrichment_core": 2,
+    "coord_enrichment_reporting": 3,
+}
+
+
+def _actual_groups():
+    """Map asset key string -> group_name from the loaded Definitions."""
+    groups = {}
+    for assets_def in defs.assets:
+        for key in assets_def.keys:
+            groups[key.to_user_string()] = assets_def.group_names_by_key[key]
+    return groups
+
+
+def test_every_asset_has_expected_group():
+    actual = _actual_groups()
+    for key, expected in EXPECTED_GROUPS.items():
+        assert actual.get(key) == expected, (
+            f"{key}: expected group {expected!r}, got {actual.get(key)!r}"
+        )
+
+
+def test_no_asset_in_default_group():
+    actual = _actual_groups()
+    in_default = sorted(k for k, g in actual.items() if g == "default")
+    assert not in_default, f"assets still in default group: {in_default}"
+
+
+def test_group_membership_counts():
+    actual = _actual_groups()
+    counts = {}
+    for group in actual.values():
+        counts[group] = counts.get(group, 0) + 1
+    assert counts == EXPECTED_COUNTS


### PR DESCRIPTION
Closes #28.

Assigns every Dagster asset to a logical `group_name` so the asset graph separates the two DAGs by instrument and role. Pure metadata change — no lineage, partition, job, schedule, or sensor behavior changes (jobs select assets by explicit `AssetSelection.assets(...)`; no `AssetSelection.groups(...)` exists, so grouping cannot alter what runs).

## Mapping (18 assets, 6 groups)

| Group | Count |
|---|---|
| `helix_spreadsheet` | 9 |
| `helix_alpss` | 2 |
| `maxima_raw` | 1 |
| `maxima_derived` | 1 |
| `coord_enrichment_core` | 2 |
| `coord_enrichment_reporting` | 3 |

## Scope

- Only `@asset` decorators touched — added `group_name="..."`. No deps/partitions/configs/docstrings changed.
- Asset checks left untouched (they inherit their target asset's group in the UI).
- No `from __future__ import annotations` added (Dagster-adjacent CI rule).

## Test

Adds `tests/test_asset_groups.py`, resolving groups from the loaded `Definitions` (`aimdl_coord_enrichment.defs`) and asserting per-asset group, the 9/2/1/1/2/3 membership counts, and that no asset remains in `default`.

`.venv/bin/pytest tests/ -v` -> 314 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
