### PR TITLE
feat: production-readiness dry run + HELIX transform-version verification

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,10 @@ from this list.
 
 Scheduled and manual sweeps of the coord_enrichment DAG live in:
 
+- `docs/runbooks/readiness_dry_run.md` — read-only
+  production-readiness dry run (GO/NO-GO rubric); run before a
+  live sweep. Driven by `operations/dry_run_readiness.py` or the
+  Dagster UI.
 - `docs/runbooks/coord_enrichment_production_sweep.md` — the
   operator-facing runbook for live sweeps.
 - `docs/runbooks/first_sweep_expected_values.md` — reference
@@ -41,9 +45,11 @@ An operator opts in via the Dagster UI.
 - **Girder** is the data management platform (REST API at data.htmdec.org)
 - **Dagster** orchestrates the metadata extraction pipeline
 - **coordinate-transformer** (`aimdl_coordinate_systems` package) handles
-  instrument-to-sample coordinate transformations. Supports versioned
-  transforms with timestamp-based version selection (v0.3.0+), though
-  `coordinates.py` does not yet pass timestamps.
+  instrument-to-sample coordinate transformations with timestamp-based
+  version selection (v0.3.0+). `coordinates.py` passes the shot timestamp,
+  so historical shots resolve to the version valid at the time. HELIX `v1`
+  applies before the 2026-04-01 recalibration and `v2` (identity — the
+  station frame was realigned to the sample frame) on/after it.
 - **IGSN** persistent identifiers link measurements to physical samples
 - **`/aimdl/datafiles`** Girder endpoint provides indexed queries by
   `meta.data_type` (no folder crawling)

--- a/docs/runbooks/coord_enrichment_production_sweep.md
+++ b/docs/runbooks/coord_enrichment_production_sweep.md
@@ -40,6 +40,11 @@ who has read and understood this document.
 
 ## Dry-run rehearsal
 
+> For a full read-only production-readiness evaluation with a GO/NO-GO
+> rubric (scripted via `operations/dry_run_readiness.py` or the UI), see
+> [`readiness_dry_run.md`](readiness_dry_run.md). The rehearsal below is
+> the lighter-weight single-partition smoke check.
+
 Run once with `dry_run=True` (the default).
 
 **MAXIMA raw** is now partitioned on

--- a/docs/runbooks/readiness_dry_run.md
+++ b/docs/runbooks/readiness_dry_run.md
@@ -1,0 +1,147 @@
+# Runbook — Production-readiness dry run (coord_enrichment)
+
+## Purpose
+
+Decide whether the `coord_enrichment` DAG is ready to write coordinate
+metadata to the live AIMD-L Girder collection. The DAG's `dry_run` flag
+(default `True`, `CoordEnrichmentConfig`) gates every Girder write, so a dry
+run reads real production data, computes every would-be write, runs every
+asset check, and **writes nothing**. The output is a single **GO / NO-GO**
+decision.
+
+The real question a dry run answers is **upstream data hygiene** — whether
+production items carry the tags the DAG depends on (`meta.igsn`,
+`meta.data_type`, and `prov.wasDerivedFrom`/`isPartOf`). Those surface as the
+ERROR-severity checks below.
+
+This is read-only. For defense in depth, run it with a **read-only Girder API
+key**: dry-run writes nothing, and a read-only key makes any accidental write
+fail loudly.
+
+This runbook does **not** cover the live sweep — see
+[`coord_enrichment_production_sweep.md`](coord_enrichment_production_sweep.md).
+
+## Go/No-Go rubric
+
+**GO requires ALL of:**
+
+- Both ERROR-severity checks PASS:
+  - `all_helix_alpss_tagged` — no unresolved HELIX ALPSS parents
+  - `maxima_xrd_derived_provenance_valid` — every `xrd_derived` item has a
+    resolvable `prov` link
+- Every `enrichment_success_rate_*` check PASSES (≥ 0.90)
+- Every `no_coord_transform_failures_*` check PASSES (zero coord failures)
+- `written == 0` on every leaf (confirms dry-run is in force)
+- Some real activity occurred — `simulated_dry_run + skipped_no_change > 0`
+  across the leaves (the DAG resolved real items; `simulated > 0` on a first
+  run, `skipped_no_change` dominates on re-runs of already-enriched data)
+- `resolution_errors == 0` across all leaves
+- `coord_transform_config_snapshot` reports a non-null `yaml_sha256`
+- `COORD_ENRICHMENT_MANIFEST_ITEM` is set to a real Girder item (the manifest
+  is not written in dry-run, but live operation needs it)
+
+**Record but do NOT block on:**
+
+- `inventory_nonempty_per_instrument` (WARN) — note any empty
+  `(instrument, data_type)` partitions
+- `pdv_coverage_above_threshold` (WARN; threshold is the placeholder `0.5` in
+  `pdv_observer.py`) — record actual coverage; feeds the threshold-tuning
+  decision in [`first_sweep_expected_values.md`](first_sweep_expected_values.md)
+
+**NO-GO signals:**
+
+- Any blocking check fails → upstream tagging/prov not ready
+- `written > 0` → dry-run breach; stop and investigate
+- Non-trivial `resolution_errors` → items can't be matched to Girder
+- `yaml_sha256` null → coordinate config broken in the deployment
+
+**Verify the transform-version split (report-only, not auto-blocked):** version
+selection is timestamp-driven — `enriched_pdv_metadata` (the HELIX root) passes
+each shot's timestamp, and the derived leaves inherit their parent's recorded
+version. HELIX `v1` applies to shots before the 2026-04-01 recalibration and
+`v2` (identity, Station == Sample, after the instrument frame was realigned to
+the sample frame) to shots on/after it. The report's "Transform versions
+applied" section and per-leaf `versions` column show the `HELIX/v1` vs
+`HELIX/v2` breakdown; confirm it matches the expected historical-vs-current
+split before the live sweep. (For HELIX this split appears via
+`enriched_helix_alpss` inheritance, which requires the parent PDV traces to be
+enriched first; if they are not, you will see `resolution_errors` instead.)
+
+## Headless path (scripted, captured)
+
+`operations/dry_run_readiness.py` runs every coord_enrichment job in dry-run
+in-process, evaluates the rubric, prints a verdict, and writes a report to
+`operations/log/readiness_dry_run_<timestamp>.{md,json}` (gitignored).
+
+1. Set the environment (use a **read-only** key):
+   ```
+   export GIRDER_API_URL="https://data.htmdec.org/api/v1"
+   export GIRDER_API_KEY="<read-only key>"
+   export COORD_TRANSFORMS_YAML="/abs/path/to/instrument_coordinate_transforms.yaml"
+   export COORD_ENRICHMENT_MANIFEST_ITEM="<girder item id>"
+   ```
+2. Quick smoke (a couple of MAXIMA raw partitions) to confirm wiring:
+   ```
+   .venv/bin/python operations/dry_run_readiness.py --sample 2
+   ```
+3. Full enumeration (every registered MAXIMA raw `(data_type, run)` partition —
+   hundreds of in-process runs; expect this to take a while):
+   ```
+   .venv/bin/python operations/dry_run_readiness.py
+   ```
+4. Read the printed `VERDICT:` line and the generated `.md` report. Exit code
+   is `0` for GO, `1` for NO-GO.
+
+`--skip-maxima-raw` evaluates only the state report and the static leaves.
+
+## UI path (full enumeration via the Dagster UI)
+
+Equivalent walkthrough for operators who prefer the UI. It produces the same
+asset-check outcomes; read them from the asset-check panel.
+
+1. Complete the pre-flight in
+   [`coord_enrichment_production_sweep.md`](coord_enrichment_production_sweep.md)
+   (env vars, manifest item, `pytest`, `dagster dev` loads).
+2. **Start `maxima_raw_discovery_sensor`.** Its first tick registers every
+   current `(igsn//experiment_date)` key on the `maxima_raw_run` dynamic dim
+   and emits one dry-run RunRequest per `(data_type, run)` — this *is* the
+   full-enumeration dry run for MAXIMA raw (runs inherit `dry_run=True`).
+   Expect hundreds of runs on the first tick.
+3. From the launchpad, run in dry-run (`dry_run: true` in run config):
+   - `coord_enrichment_helix_alpss_job` — all three `HELIX/pdv_alpss_*` partitions
+   - `coord_enrichment_maxima_derived_job` — `MAXIMA/xrd_derived`
+   - `coord_enrichment_job` — the state report (run last, so the report asset
+     sees leaf coverage)
+4. Read the asset-check panel and the per-leaf output metadata
+   (`written`, `simulated_dry_run`, `resolution_errors`, …) against the rubric.
+
+## Results table
+
+Fill this in from the report (or the UI) and attach it to the go/no-go
+decision. On GO, transcribe the counts into
+[`first_sweep_expected_values.md`](first_sweep_expected_values.md) as the
+reference baseline.
+
+| Check | Severity | Blocking | Result (PASS/FAIL) | Notes |
+|---|---|:-:|:-:|---|
+| `all_helix_alpss_tagged` | ERROR | yes | | |
+| `maxima_xrd_derived_provenance_valid` | ERROR | yes | | |
+| `enrichment_success_rate_maxima_raw` | WARN | yes | | per partition |
+| `no_coord_transform_failures_maxima_raw` | WARN | yes | | per partition |
+| `enrichment_success_rate_helix_alpss` | WARN | yes | | per partition |
+| `no_coord_transform_failures_helix_alpss` | WARN | yes | | per partition |
+| `enrichment_success_rate_maxima_derived` | WARN | yes | | |
+| `no_coord_transform_failures_maxima_derived` | WARN | yes | | |
+| `inventory_nonempty_per_instrument` | WARN | no | | record empties |
+| `pdv_coverage_above_threshold` | WARN | no | | record coverage |
+
+| Leaf | seen | written | simulated | skipped | coord_fail | res_err |
+|---|--:|--:|--:|--:|--:|--:|
+| `enriched_maxima_raw` | | | | | | |
+| `enriched_helix_alpss` | | | | | | |
+| `enriched_maxima_derived` | | | | | | |
+
+**Decision:** GO / NO-GO — _________   **Date:** _________
+
+If NO-GO, the failing ERROR checks name the upstream tagging/prov work to do
+before re-running this dry run.

--- a/operations/dry_run_readiness.py
+++ b/operations/dry_run_readiness.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python
+"""Read-only production-readiness dry run for the coord_enrichment DAG.
+
+Runs every coord_enrichment job in dry-run (``dry_run=True`` — no Girder
+writes) against the configured Girder instance, collects asset-check
+outcomes and per-leaf counters, evaluates them against the go/no-go
+rubric, and writes a report to ``operations/log/``.
+
+Dry-run performs no writes. For defense in depth, run this with a
+READ-ONLY Girder API key so that any accidental write fails loudly.
+
+See docs/runbooks/readiness_dry_run.md for the rubric and the
+UI-driven equivalent.
+
+Usage:
+    .venv/bin/python operations/dry_run_readiness.py            # full enumeration
+    .venv/bin/python operations/dry_run_readiness.py --sample 2 # quick smoke
+"""
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+
+
+REQUIRED_ENV = ["GIRDER_API_URL", "GIRDER_API_KEY", "COORD_TRANSFORMS_YAML"]
+
+HELIX_ALPSS_KEYS = [
+    "HELIX/pdv_alpss_output",
+    "HELIX/pdv_alpss_result",
+    "HELIX/pdv_alpss_results",
+]
+MAXIMA_DERIVED_KEY = "MAXIMA/xrd_derived"
+MAXIMA_RAW_DATA_TYPES = ("xrd_raw", "xrf_raw")
+
+# A check blocks GO if it is ERROR-severity or its name starts with one of
+# these prefixes. Everything else (inventory_nonempty_per_instrument,
+# pdv_coverage_above_threshold) is recorded but non-blocking.
+BLOCKING_WARN_PREFIXES = ("enrichment_success_rate", "no_coord_transform_failures")
+
+
+def preflight():
+    missing = [v for v in REQUIRED_ENV if not os.environ.get(v)]
+    if missing:
+        sys.exit("Missing required env vars: " + ", ".join(missing))
+    warnings = []
+    if not os.environ.get("COORD_ENRICHMENT_MANIFEST_ITEM"):
+        warnings.append(
+            "COORD_ENRICHMENT_MANIFEST_ITEM is not set — the manifest write "
+            "path is not exercised; live operation requires it."
+        )
+    return warnings
+
+
+def _plain(value):
+    """Best-effort unwrap of a Dagster MetadataValue for JSON output."""
+    return getattr(value, "value", str(value))
+
+
+def _is_blocking(check_name, severity):
+    return severity == "ERROR" or check_name.startswith(BLOCKING_WARN_PREFIXES)
+
+
+def _version_breakdown(leaves):
+    """Aggregate transform_version counts across all leaves.
+
+    Keys look like ``HELIX/v1``, ``HELIX/v2``, ``MAXIMA/v1``. For HELIX the
+    count comes from enriched_helix_alpss inheriting its parent PDV trace's
+    recorded version, so v1 = historical shots, v2 = post-2026-04-01 shots
+    (identity, Station == Sample).
+    """
+    totals = {}
+    for v in leaves.values():
+        for ver, n in v.get("versions", {}).items():
+            totals[ver] = totals.get(ver, 0) + n
+    return totals
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--sample", type=int, default=None,
+        help="Limit MAXIMA raw to the first N (data_type, run) partitions "
+             "for a quick smoke pass. Default: full enumeration.",
+    )
+    parser.add_argument(
+        "--skip-maxima-raw", action="store_true",
+        help="Skip the MAXIMA raw dynamic-partition sweep entirely.",
+    )
+    args = parser.parse_args()
+
+    pre_warnings = preflight()
+
+    # Imports deferred until after env preflight: aimdl_coord_enrichment.coordinates
+    # loads the coordinate-transformer at import time from COORD_TRANSFORMS_YAML.
+    import requests
+    from dagster import DagsterInstance, MultiPartitionKey
+
+    from aimdl_coord_enrichment import defs
+    from aimdl_coord_enrichment.coord_enrichment import MAXIMA_RUN_PARTITIONS
+    from aimdl_coord_enrichment.coordinates import _COORD_TRANSFORMER, _COORD_YAML
+    from aimdl_coord_enrichment.girder_io import fetch_partition_index
+    from aimdl_coord_enrichment.resources import GirderClientWithSession
+    from aimdl_coord_enrichment.schedules import (
+        _HELIX_ALPSS_OPS,
+        _MAXIMA_DERIVED_OPS,
+        _MAXIMA_RAW_OPS,
+        _STATE_REPORT_OPS,
+        _dry_run_config,
+    )
+
+    if _COORD_TRANSFORMER is None:
+        sys.exit(
+            f"coordinate-transformer failed to load (COORD_TRANSFORMS_YAML={_COORD_YAML}). "
+            "Install the coordinate-transformer package and point the env var at a valid YAML."
+        )
+
+    instance = DagsterInstance.ephemeral()
+    checks = []        # one record per asset-check evaluation
+    leaves = {}        # leaf node name -> aggregated counters
+    run_failures = []  # job executions that errored outright
+
+    def harvest_checks(result, label):
+        for ev in result.get_asset_check_evaluations():
+            checks.append({
+                "run": label,
+                "check": ev.check_name,
+                "asset": ev.asset_key.to_user_string(),
+                "passed": bool(ev.passed),
+                "severity": ev.severity.value,
+                "metadata": {k: _plain(v) for k, v in (ev.metadata or {}).items()},
+            })
+
+    def harvest_leaf(result, node_name):
+        if not result.success:
+            return
+        try:
+            out = result.output_for_node(node_name)
+        except Exception:
+            return
+        counts = out.get("counts", {})
+        agg = leaves.setdefault(node_name, {
+            "seen": 0, "written": 0, "simulated_dry_run": 0,
+            "skipped_no_change": 0, "coord_failures": 0,
+            "resolution_errors": 0, "partitions": 0, "versions": {},
+        })
+        for k in ("seen", "written", "simulated_dry_run", "skipped_no_change",
+                  "coord_failures", "resolution_errors"):
+            agg[k] += int(counts.get(k, 0))
+        agg["partitions"] += 1
+        for ver, n in (out.get("version_counter") or {}).items():
+            agg["versions"][ver] = agg["versions"].get(ver, 0) + n
+
+    def run(job_name, label, run_config, partition_key=None):
+        job = defs.resolve_job_def(job_name)
+        result = job.execute_in_process(
+            instance=instance,
+            partition_key=partition_key,
+            run_config=run_config,
+            raise_on_error=False,
+        )
+        if not result.success:
+            run_failures.append(label)
+            print(f"  [FAILED] {label}", flush=True)
+        harvest_checks(result, label)
+        return result
+
+    # --- MAXIMA raw: enumerate dynamic run keys (read-only) and register them ---
+    pairs = []
+    if not args.skip_maxima_raw:
+        session = requests.Session()
+        client = GirderClientWithSession(
+            apiUrl=os.environ["GIRDER_API_URL"],
+            apiKey=os.environ["GIRDER_API_KEY"],
+            session=session,
+        )
+        run_keys = sorted({
+            key
+            for dt in MAXIMA_RAW_DATA_TYPES
+            for key in fetch_partition_index(client, dt).keys()
+        })
+        if run_keys:
+            instance.add_dynamic_partitions(MAXIMA_RUN_PARTITIONS.name, run_keys)
+        pairs = [(dt, rk) for dt in MAXIMA_RAW_DATA_TYPES for rk in run_keys]
+        if args.sample is not None:
+            pairs = pairs[:args.sample]
+        print(f"MAXIMA raw: {len(run_keys)} run keys, sweeping {len(pairs)} partitions", flush=True)
+        cfg = _dry_run_config(_MAXIMA_RAW_OPS)
+        for i, (dt, rk) in enumerate(pairs, 1):
+            pk = MultiPartitionKey({"data_type": dt, "run": rk})
+            print(f"  [{i}/{len(pairs)}] {dt} / {rk}", flush=True)
+            res = run("coord_enrichment_maxima_raw_partition_job",
+                      f"maxima_raw:{dt}/{rk}", cfg, partition_key=pk)
+            harvest_leaf(res, "enriched_maxima_raw")
+
+    # --- HELIX ALPSS static partitions ---
+    print("HELIX ALPSS: 3 partitions", flush=True)
+    for pk in HELIX_ALPSS_KEYS:
+        res = run("coord_enrichment_helix_alpss_job",
+                  f"helix_alpss:{pk}", _dry_run_config(_HELIX_ALPSS_OPS),
+                  partition_key=pk)
+        harvest_leaf(res, "enriched_helix_alpss")
+
+    # --- MAXIMA derived single static partition ---
+    print("MAXIMA derived: 1 partition", flush=True)
+    res = run("coord_enrichment_maxima_derived_job",
+              f"maxima_derived:{MAXIMA_DERIVED_KEY}",
+              _dry_run_config(_MAXIMA_DERIVED_OPS),
+              partition_key=MAXIMA_DERIVED_KEY)
+    harvest_leaf(res, "enriched_maxima_derived")
+
+    # --- State report last, so the report asset sees leaf coverage ---
+    print("State report", flush=True)
+    state_res = run("coord_enrichment_job", "state_report",
+                    _dry_run_config(_STATE_REPORT_OPS))
+    snapshot = None
+    if state_res.success:
+        try:
+            snap = state_res.output_for_node("coord_transform_config_snapshot")
+            snapshot = {
+                "yaml_path": snap.yaml_path,
+                "yaml_sha256": snap.yaml_sha256,
+                "transformer_version": snap.transformer_version,
+                "versions_by_instrument": snap.versions_by_instrument,
+            }
+        except Exception:
+            pass
+
+    verdict = _evaluate(checks, leaves, snapshot, run_failures, pre_warnings)
+    _write_report(checks, leaves, snapshot, run_failures, pre_warnings, verdict)
+    print()
+    versions = _version_breakdown(leaves)
+    print("Transform versions applied: " + (
+        ", ".join(f"{k}={n}" for k, n in sorted(versions.items())) or "none"
+    ))
+    print(verdict["line"])
+    sys.exit(0 if verdict["go"] else 1)
+
+
+def _evaluate(checks, leaves, snapshot, run_failures, pre_warnings):
+    reasons = []
+
+    for label in run_failures:
+        reasons.append(f"job execution failed: {label}")
+
+    for c in checks:
+        if _is_blocking(c["check"], c["severity"]) and not c["passed"]:
+            reasons.append(f"{c['severity']} check failed: {c['check']} ({c['run']})")
+
+    total_written = sum(v["written"] for v in leaves.values())
+    total_sim = sum(v["simulated_dry_run"] for v in leaves.values())
+    total_skip = sum(v["skipped_no_change"] for v in leaves.values())
+    total_res_err = sum(v["resolution_errors"] for v in leaves.values())
+
+    if total_written > 0:
+        reasons.append(f"DRY-RUN BREACH: {total_written} items were written (expected 0)")
+    if total_res_err > 0:
+        reasons.append(f"{total_res_err} resolution errors across leaves")
+    if (total_sim + total_skip + total_written) == 0:
+        reasons.append("no items resolved in any leaf — nothing was evaluated")
+
+    if snapshot is None or not snapshot.get("yaml_sha256"):
+        reasons.append("coordinate-transform snapshot missing yaml_sha256")
+
+    if not os.environ.get("COORD_ENRICHMENT_MANIFEST_ITEM"):
+        reasons.append("COORD_ENRICHMENT_MANIFEST_ITEM unset (required for live operation)")
+
+    go = not reasons
+    line = "VERDICT: GO" if go else "VERDICT: NO-GO"
+    if not go:
+        line += " — " + "; ".join(reasons)
+    return {"go": go, "reasons": reasons, "line": line}
+
+
+def _write_report(checks, leaves, snapshot, run_failures, pre_warnings, verdict):
+    log_dir = os.path.join(os.path.dirname(__file__), "log")
+    os.makedirs(log_dir, exist_ok=True)
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    base = os.path.join(log_dir, f"readiness_dry_run_{stamp}")
+
+    payload = {
+        "timestamp_utc": stamp,
+        "verdict": verdict,
+        "preflight_warnings": pre_warnings,
+        "run_failures": run_failures,
+        "snapshot": snapshot,
+        "transform_versions": _version_breakdown(leaves),
+        "leaves": leaves,
+        "checks": checks,
+    }
+    with open(base + ".json", "w") as f:
+        json.dump(payload, f, indent=2, default=str)
+
+    lines = [f"# Readiness dry run — {stamp}", "", f"**{verdict['line']}**", ""]
+    if verdict["reasons"]:
+        lines.append("## Blocking reasons")
+        lines += [f"- {r}" for r in verdict["reasons"]] + [""]
+    if pre_warnings:
+        lines.append("## Pre-flight warnings")
+        lines += [f"- {w}" for w in pre_warnings] + [""]
+
+    lines.append("## Leaf counters (dry-run)")
+    lines.append("")
+    lines.append("| Leaf | partitions | seen | written | simulated | skipped | coord_fail | res_err | versions |")
+    lines.append("|---|--:|--:|--:|--:|--:|--:|--:|---|")
+    for name, v in sorted(leaves.items()):
+        versions = ", ".join(f"{k}={n}" for k, n in sorted(v["versions"].items())) or "—"
+        lines.append(
+            f"| {name} | {v['partitions']} | {v['seen']} | {v['written']} | "
+            f"{v['simulated_dry_run']} | {v['skipped_no_change']} | "
+            f"{v['coord_failures']} | {v['resolution_errors']} | {versions} |"
+        )
+    lines.append("")
+
+    versions = _version_breakdown(leaves)
+    lines.append("## Transform versions applied")
+    lines.append("")
+    lines.append(
+        "Counts of the coordinate transform version actually selected per item "
+        "(dry-run still resolves versions). For HELIX these come from "
+        "`enriched_helix_alpss` inheriting the parent PDV trace's recorded "
+        "version — `HELIX/v1` = pre-2026-04-01 shots, `HELIX/v2` = post-cutover "
+        "shots (identity, Station == Sample). A missing HELIX split usually means "
+        "parent PDV traces are not yet enriched (see `resolution_errors`)."
+    )
+    lines.append("")
+    lines.append("| Version | count |")
+    lines.append("|---|--:|")
+    for ver, n in sorted(versions.items()):
+        lines.append(f"| {ver} | {n} |")
+    if not versions:
+        lines.append("| (none resolved) | 0 |")
+    lines.append("")
+
+    if snapshot:
+        lines += [
+            "## Coordinate-transform snapshot",
+            "",
+            f"- yaml_sha256: `{snapshot.get('yaml_sha256')}`",
+            f"- transformer_version: `{snapshot.get('transformer_version')}`",
+            f"- instruments: {', '.join(sorted(snapshot.get('versions_by_instrument', {}))) or '—'}",
+            "",
+        ]
+
+    lines.append("## Asset checks")
+    lines.append("")
+    lines.append("| Check | severity | blocking | result | run |")
+    lines.append("|---|---|:-:|:-:|---|")
+    for c in sorted(checks, key=lambda c: (c["severity"], c["check"], c["run"])):
+        blocking = "yes" if _is_blocking(c["check"], c["severity"]) else "no"
+        result = "PASS" if c["passed"] else "FAIL"
+        lines.append(f"| {c['check']} | {c['severity']} | {blocking} | {result} | {c['run']} |")
+    lines.append("")
+
+    with open(base + ".md", "w") as f:
+        f.write("\n".join(lines))
+
+    print(f"\nReport written to:\n  {base}.md\n  {base}.json")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_coordinates.py
+++ b/tests/test_coordinates.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -128,3 +128,74 @@ def test_transform_with_named_version_missing_transformer_returns_none():
         assert sy is None
     finally:
         coord_mod._COORD_TRANSFORMER = original
+
+
+# --- HELIX version-selection boundary tests ---
+#
+# HELIX recalibrated on 2026-04-01T00:00:00-04:00: the instrument's station
+# frame was physically realigned to match the sample frame, so from that
+# instant on Station == Sample (v2 = identity). Earlier shots use v1, a
+# horizontal flip about x=20 (x' = 40 - x, y' = y). These tests lock the
+# cutover instant and the value-level behavior through the timestamp-driven
+# selection path, so a future YAML edit can't silently move the boundary or
+# break the realignment. valid_from is inclusive, valid_until exclusive.
+
+HELIX_V2_CUTOVER_UTC = datetime(2026, 4, 1, 4, 0, 0, tzinfo=timezone.utc)
+# 2026-04-01T04:00:00Z == 2026-04-01T00:00:00-04:00 (the YAML boundary)
+
+
+def test_helix_v1_flip_before_cutover():
+    """A pre-cutover shot resolves to v1 and applies the horizontal flip."""
+    if _COORD_TRANSFORMER is None:
+        pytest.skip("COORD_TRANSFORMS_YAML not available")
+    ts = HELIX_V2_CUTOVER_UTC - timedelta(days=30)
+    sx, sy, name = transform_station_to_sample(8.0, 8.0, instrument="HELIX", timestamp=ts)
+    assert name == "HELIX/v1"
+    assert sx == pytest.approx(32.0, abs=1e-6)  # 40 - 8
+    assert sy == pytest.approx(8.0, abs=1e-6)
+
+
+def test_helix_v2_identity_after_cutover():
+    """A post-cutover shot resolves to v2 (identity: Station == Sample)."""
+    if _COORD_TRANSFORMER is None:
+        pytest.skip("COORD_TRANSFORMS_YAML not available")
+    ts = HELIX_V2_CUTOVER_UTC + timedelta(days=30)
+    sx, sy, name = transform_station_to_sample(8.0, 8.0, instrument="HELIX", timestamp=ts)
+    assert name == "HELIX/v2"
+    assert sx == pytest.approx(8.0, abs=1e-6)
+    assert sy == pytest.approx(8.0, abs=1e-6)
+
+
+def test_helix_boundary_just_before_is_v1():
+    """One second before the cutover still resolves to v1 (valid_until exclusive)."""
+    if _COORD_TRANSFORMER is None:
+        pytest.skip("COORD_TRANSFORMS_YAML not available")
+    ts = HELIX_V2_CUTOVER_UTC - timedelta(seconds=1)
+    _, _, name = transform_station_to_sample(8.0, 8.0, instrument="HELIX", timestamp=ts)
+    assert name == "HELIX/v1"
+
+
+def test_helix_boundary_at_cutover_is_v2():
+    """Exactly at the cutover instant resolves to v2 (valid_from inclusive)."""
+    if _COORD_TRANSFORMER is None:
+        pytest.skip("COORD_TRANSFORMS_YAML not available")
+    _, _, name = transform_station_to_sample(
+        8.0, 8.0, instrument="HELIX", timestamp=HELIX_V2_CUTOVER_UTC
+    )
+    assert name == "HELIX/v2"
+
+
+def test_helix_version_changes_result_across_cutover():
+    """The same station point yields different sample coords on either side
+    of the cutover, proving version selection actually drives the math."""
+    if _COORD_TRANSFORMER is None:
+        pytest.skip("COORD_TRANSFORMS_YAML not available")
+    before = transform_station_to_sample(
+        8.0, 8.0, instrument="HELIX", timestamp=HELIX_V2_CUTOVER_UTC - timedelta(seconds=1)
+    )
+    at = transform_station_to_sample(
+        8.0, 8.0, instrument="HELIX", timestamp=HELIX_V2_CUTOVER_UTC
+    )
+    assert before[2] == "HELIX/v1"
+    assert at[2] == "HELIX/v2"
+    assert before[:2] != at[:2]


### PR DESCRIPTION
Adds a read-only production-readiness dry run for the `coord_enrichment` DAG and locks down HELIX coordinate-transform version selection. No DAG behavior changes — new tooling, tests, and docs only.

## Readiness dry run
- **`operations/dry_run_readiness.py`** — runs every `coord_enrichment` job in dry-run (`dry_run=True`, no Girder writes) in-process, collects asset-check outcomes + per-leaf counters, evaluates a GO/NO-GO rubric, and writes a report to `operations/log/` (gitignored). Full MAXIMA-raw dynamic-partition enumeration, with an optional `--sample N` smoke mode. Reuses `defs`, the schedule dry-run config, and the discovery sensor's partition-index fetch. Recommended with a **read-only** Girder key for defense in depth.
- **`docs/runbooks/readiness_dry_run.md`** — the GO/NO-GO rubric, headless + UI walkthroughs, and a results table that seeds `first_sweep_expected_values.md`.
- Cross-references from `CLAUDE.md` and the production-sweep runbook.

## HELIX transform versioning
The DAG already does timestamp-based version selection (`enriched_pdv_metadata` passes the shot timestamp; derived leaves inherit the parent's recorded version). This PR makes that guarantee durable and visible:
- **`tests/test_coordinates.py`** — 5 regression tests locking the **2026-04-01 cutover**: `v1` flip before, `v2` identity on/after (the station frame was physically realigned to the sample frame, so Station == Sample), plus the inclusive-`valid_from` / exclusive-`valid_until` boundary.
- **Dry-run report** now surfaces the `HELIX/v1` vs `HELIX/v2` split (consolidated "Transform versions applied" section + stdout + JSON), so the historical-vs-current split can be verified before go-live.
- Corrected stale docs (`CLAUDE.md`, the readiness runbook, and the gitignored context doc) that wrongly claimed `coordinates.py` does not pass timestamps.

## Test
`.venv/bin/pytest tests/` -> **319 passed, 1 skipped** (+5 new).

## Notes
- The script reports the HELIX version split as seen via `enriched_helix_alpss` inheritance (the coord_enrichment scope); the HELIX *root* PDV-trace coords come from the separate spreadsheet DAG. Root-level surfacing is a possible follow-up.
- Reports land in `operations/log/` which is gitignored, so no run artifacts are committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
