### PR TITLE
Refactor helix_spreadsheet from 9 assets to 3 partitioned assets (#31)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ PDV inventory as an ERROR in the Dagster UI.
 - **What it does:** Three durable partitioned assets — `pdv_log` (read + normalize + validate the experiment log for the partition), `pdv_data` (fetch the PDV trace inventory, match rows by filename, **write coordinate metadata to `pdv_trace` items**), and `pdv_processing_manifest` (stamp `meta.processing_status` back onto each source log item).
 - **Coordinate source:** each spreadsheet row's `Flyer_X/Y_Position_Corrected (mm)` becomes `Station_X/Y`; the row `Timestamp` selects the HELIX transform version.
 - **Writing asset:** `pdv_data` → `pdv_trace`.
+- **Dry run:** `pdv_data` and `pdv_processing_manifest` take a `dry_run` config (`HelixSpreadsheetConfig`, **default `True`**). When dry, all reads/matching/transforms run but the Girder writes are simulated — checks count the would-be writes so a rehearsal reads as a live run. Set `dry_run: false` on both assets in the launchpad for a live sweep. (Because the default is safe, even an accidentally-enabled sensor run writes nothing.)
 
 ### 2. `coord_enrichment_job` — state report (read-only)
 - **Trigger:** `coord_enrichment_state_report_schedule` (nightly 03:00 ET, ships STOPPED).

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ each HELIX and MAXIMA file type, and where those coordinates come from:
 
 | Instrument | `data_type` (Girder) | Role | Writing asset | Job | Coordinate source |
 |---|---|---|---|---|---|
-| HELIX | `pdv_trace` | leaf | `enriched_pdv_metadata` | `process_helix_assets_job` | Spreadsheet row `Flyer_X/Y_Position_Corrected` |
+| HELIX | `pdv_trace` | leaf | `pdv_data` | `process_helix_assets_job` | Spreadsheet row `Flyer_X/Y_Position_Corrected` |
 | HELIX | `pdv_alpss_output` | derived | `enriched_helix_alpss` | `coord_enrichment_helix_alpss_job` | Inherited from parent `pdv_trace` |
 | HELIX | `pdv_alpss_result` | derived | `enriched_helix_alpss` | `coord_enrichment_helix_alpss_job` | Inherited from parent `pdv_trace` |
 | HELIX | `pdv_alpss_results` | derived | `enriched_helix_alpss` | `coord_enrichment_helix_alpss_job` | Inherited from parent `pdv_trace` |
@@ -77,22 +77,24 @@ spreadsheets appear in the HELIX folder.
 
 ### Prerequisite: IGSN tagging
 
-The `pdv_trace_inventory` and `alpss_results_inventory` assets use the
-`/aimdl/datafiles` Girder endpoint, which requires `meta.igsn` and
+The `pdv_log` asset partitions on `pdv_experiment_log` via the
+`/aimdl/partition` Girder endpoint, and `pdv_data` fetches the PDV trace
+inventory via `/aimdl/datafiles`. Both require `meta.igsn` and
 `meta.data_type` to be set on items. Until these metadata fields are tagged
-on PDV files in Girder, the inventories will return incomplete results.
-The `zero_inventory` asset check will flag this as an ERROR in the Dagster UI.
+on experiment-log and PDV files in Girder, the flow is inert / returns
+incomplete results. The `zero_pdv_inventory` asset check will flag an empty
+PDV inventory as an ERROR in the Dagster UI.
 
 --
 
 ## Job-by-job details
 
-### 1. `process_helix_assets_job` — HELIX spreadsheet DAG
-- **Trigger:** `helix_folder_sensor` (polls the HELIX folder for new experiment-log spreadsheets).
-- **Partitioning:** none — one run per spreadsheet item.
-- **What it does:** Downloads a HELIX experiment-log spreadsheet, validates IGSNs, fetches the PDV trace inventory, matches PDV files to spreadsheet rows by filename, and **writes coordinate metadata to `pdv_trace` items**. Aggregates a quality report and stamps `meta.processing_status` back onto the source spreadsheet item.
+### 1. `process_helix_assets_job` — HELIX spreadsheet flow
+- **Trigger:** `helix_experiment_log_discovery_sensor` (polls `/aimdl/partition` for `pdv_experiment_log`, registers partitions, emits one partitioned RunRequest per changed log).
+- **Partitioning:** `HELIX_EXPERIMENT_LOG_PARTITIONS` = `DynamicPartitionsDefinition("helix_experiment_log")`, keyed on the AIMD-L logical key `<igsn>//<experiment_date>`.
+- **What it does:** Three durable partitioned assets — `pdv_log` (read + normalize + validate the experiment log for the partition), `pdv_data` (fetch the PDV trace inventory, match rows by filename, **write coordinate metadata to `pdv_trace` items**), and `pdv_processing_manifest` (stamp `meta.processing_status` back onto each source log item).
 - **Coordinate source:** each spreadsheet row's `Flyer_X/Y_Position_Corrected (mm)` becomes `Station_X/Y`; the row `Timestamp` selects the HELIX transform version.
-- **Writing asset:** `enriched_pdv_metadata` → `pdv_trace`.
+- **Writing asset:** `pdv_data` → `pdv_trace`.
 
 ### 2. `coord_enrichment_job` — state report (read-only)
 - **Trigger:** `coord_enrichment_state_report_schedule` (nightly 03:00 ET, ships STOPPED).
@@ -129,16 +131,15 @@ The `zero_inventory` asset check will flag this as an ERROR in the Dagster UI.
 
 ### Assets
 
+The `helix_spreadsheet` flow is three partitioned assets (assets model
+durable external-state transitions; pure computation lives in
+`spreadsheet.py` helpers):
+
 | Asset | Description |
 |---|---|
-| `raw_experiment_log` | Downloads a spreadsheet from Girder and applies column renaming |
-| `pdv_trace_inventory` | Fetches PDV trace items via `/aimdl/datafiles` (indexed query, no folder crawl) |
-| `validated_rows` | Validates IGSN identifiers on each row (pure transformation) |
-| `pdv_cross_references` | Matches PDV filenames to inventory items, checks IGSN consistency |
-| `enriched_pdv_metadata` | Writes coordinate and flyer position metadata to matched Girder items |
-| `alpss_results_inventory` | Fetches ALPSS result items via `/aimdl/datafiles` for completeness reporting |
-| `quality_report` | Aggregates all issues and ALPSS completeness metrics |
-| `processing_manifest` | Writes a structured processing record to the source Girder item |
+| `pdv_log` | Reads the experiment log(s) for the partition, applies column renaming, and validates IGSN identifiers per row |
+| `pdv_data` | Fetches the PDV trace inventory via `/aimdl/datafiles`, matches PDV filenames to rows (checking IGSN consistency), and writes coordinate + provenance metadata to matched `pdv_trace` items |
+| `pdv_processing_manifest` | Writes a structured processing record to each source experiment-log item |
 
 ### Asset checks
 
@@ -147,17 +148,18 @@ pass/warn/fail indicators in the Dagster UI:
 
 | Check | Asset | Severity | Triggers when |
 |---|---|---|---|
-| `zero_inventory` | `pdv_trace_inventory` | ERROR | Inventory returned 0 items |
-| `igsn_validity_rate` | `validated_rows` | WARN | <80% of rows have valid IGSNs |
-| `pdv_match_rate` | `pdv_cross_references` | WARN | <50% of PDV filenames matched |
-| `igsn_consistency` | `pdv_cross_references` | ERROR | IGSN mismatch between spreadsheet and Girder |
-| `enrichment_success_rate` | `enriched_pdv_metadata` | WARN | <90% of matched items enriched |
-| `coord_transform_check` | `enriched_pdv_metadata` | WARN | Any coordinate transform failures |
+| `igsn_validity_rate` | `pdv_log` | WARN | <80% of rows have valid IGSNs |
+| `zero_pdv_inventory` | `pdv_data` | ERROR | PDV trace inventory returned 0 items |
+| `pdv_match_rate` | `pdv_data` | WARN | <50% of PDV filenames matched |
+| `igsn_consistency` | `pdv_data` | ERROR | IGSN mismatch between spreadsheet and Girder |
+| `enrichment_success_rate` | `pdv_data` | WARN | <90% of matched items enriched |
+| `coord_transform_check` | `pdv_data` | WARN | Any coordinate transform failures |
+| `manifest_written` | `pdv_processing_manifest` | ERROR | Processing manifest write failed for any source item |
 
 ### Processing manifest
 
-After each run, the `processing_manifest` asset writes `meta.processing_status`
-to the source spreadsheet's Girder item:
+After each run, the `pdv_processing_manifest` asset writes
+`meta.processing_status` to each source experiment-log Girder item:
 
 ```json
 {
@@ -185,10 +187,12 @@ sensor to skip already-processed spreadsheets.
 
 ### Sensor
 
-The `helix_folder_sensor` polls the HELIX Girder folder for new spreadsheets
-using a sorted recent-items query (not a recursive folder crawl). Spreadsheets
-already processed cleanly (per `meta.processing_status`) are automatically
-skipped.
+The `helix_experiment_log_discovery_sensor` polls `/aimdl/partition` for
+`pdv_experiment_log` items, registers each AIMD-L key
+(`<igsn>//<experiment_date>`) on the `helix_experiment_log` dynamic
+partition dimension, and emits one partitioned RunRequest per key. The
+run_key embeds the partition's content hash, so unchanged logs are
+suppressed and a changed log re-triggers. Ships **STOPPED**.
 
 ## Setup
 

--- a/aimdl_coord_enrichment/__init__.py
+++ b/aimdl_coord_enrichment/__init__.py
@@ -3,24 +3,19 @@ __version__ = "0.6.0"
 from dagster import AssetSelection, Definitions, EnvVar, define_asset_job
 
 from aimdl_coord_enrichment.assets import (
-    alpss_results_inventory,
-    enriched_pdv_metadata,
-    experiment_log_source,
-    pdv_cross_references,
-    pdv_trace_inventory,
+    pdv_data,
+    pdv_log,
+    pdv_processing_manifest,
     process_helix_assets_job,
-    processing_manifest,
-    quality_report,
-    raw_experiment_log,
-    validated_rows,
 )
 from aimdl_coord_enrichment.checks import (
     coord_transform_check,
     enrichment_success_rate,
     igsn_consistency,
     igsn_validity_rate,
+    manifest_written,
     pdv_match_rate,
-    zero_inventory,
+    zero_pdv_inventory,
 )
 from aimdl_coord_enrichment.coord_enrichment import (
     coord_enrichment_manifest,
@@ -53,7 +48,7 @@ from aimdl_coord_enrichment.schedules import (
     coord_enrichment_state_report_schedule,
 )
 from aimdl_coord_enrichment.sensors import (
-    helix_folder_sensor,
+    helix_experiment_log_discovery_sensor,
     maxima_raw_discovery_sensor,
 )
 
@@ -122,16 +117,10 @@ coord_enrichment_maxima_derived_job = define_asset_job(
 
 defs = Definitions(
     assets=[
-        # existing
-        experiment_log_source,
-        raw_experiment_log,
-        pdv_trace_inventory,
-        validated_rows,
-        pdv_cross_references,
-        enriched_pdv_metadata,
-        alpss_results_inventory,
-        quality_report,
-        processing_manifest,
+        # helix_spreadsheet (3 partitioned assets)
+        pdv_log,
+        pdv_data,
+        pdv_processing_manifest,
         # coord_enrichment (Phase 3)
         coord_transform_config_snapshot,
         enrichable_items_inventory,
@@ -145,13 +134,14 @@ defs = Definitions(
         helix_pdv_coverage_observer,
     ],
     asset_checks=[
-        # existing
-        zero_inventory,
+        # helix_spreadsheet (retargeted to the 3-asset flow)
         igsn_validity_rate,
+        zero_pdv_inventory,
         pdv_match_rate,
         igsn_consistency,
         enrichment_success_rate,
         coord_transform_check,
+        manifest_written,
         # coord_enrichment (Phase 3)
         inventory_nonempty_per_instrument,
         all_helix_alpss_tagged,
@@ -180,7 +170,7 @@ defs = Definitions(
         coord_enrichment_maxima_derived_weekly_schedule,
     ],
     sensors=[
-        helix_folder_sensor,
+        helix_experiment_log_discovery_sensor,
         maxima_raw_discovery_sensor,
     ],
     resources={

--- a/aimdl_coord_enrichment/assets.py
+++ b/aimdl_coord_enrichment/assets.py
@@ -94,11 +94,18 @@ def pdv_log(
 
     combined, igsn_issues = validate_log_rows(combined)
 
+    valid_igsn_count = (
+        int(combined["valid_igsn"].notna().sum())
+        if "valid_igsn" in combined.columns
+        else 0
+    )
+
     context.add_output_metadata(
         {
             "partition_key": MetadataValue.text(key),
             "source_item_count": MetadataValue.int(len(source_item_ids)),
             "row_count": MetadataValue.int(len(combined)),
+            "valid_igsn_count": MetadataValue.int(valid_igsn_count),
             "igsn_issue_count": MetadataValue.int(len(igsn_issues)),
         }
     )
@@ -178,16 +185,25 @@ def pdv_data(
         )
 
     version_counter = write_summary["version_counter"]
+    rows_with_pdv = count_rows_with_pdv(df)
+    igsn_mismatch_count = sum(
+        1 for i in pdv_issues if i.get("type") == "igsn_mismatch"
+    )
     context.add_output_metadata(
         {
             "dry_run": MetadataValue.bool(config.dry_run),
             "inventory_count": MetadataValue.int(len(inventory)),
             "matched_count": MetadataValue.int(len(matches)),
+            "rows_with_pdv": MetadataValue.int(rows_with_pdv),
             "items_enriched": MetadataValue.int(write_summary["written_count"]),
             "items_simulated": MetadataValue.int(write_summary["simulated_count"]),
+            "write_errors_count": MetadataValue.int(len(write_summary["write_errors"])),
+            "igsn_mismatch_count": MetadataValue.int(igsn_mismatch_count),
             "coordinate_transform_failures": MetadataValue.int(
                 write_summary["coord_failures"]
             ),
+            "transform_version_count": MetadataValue.int(len(version_counter)),
+            "yaml_sha256_present": MetadataValue.bool(yaml_sha256 is not None),
             "transform_versions_used": MetadataValue.text(
                 ", ".join(f"{k}={v}" for k, v in sorted(version_counter.items()))
                 or "none"
@@ -198,7 +214,7 @@ def pdv_data(
         "dry_run": config.dry_run,
         "inventory_count": len(inventory),
         "matched_count": len(matches),
-        "rows_with_pdv": count_rows_with_pdv(df),
+        "rows_with_pdv": rows_with_pdv,
         "pdv_issues": pdv_issues,
         "written_count": write_summary["written_count"],
         "simulated_count": write_summary["simulated_count"],

--- a/aimdl_coord_enrichment/assets.py
+++ b/aimdl_coord_enrichment/assets.py
@@ -1,213 +1,122 @@
-import json
-from datetime import datetime, timezone
-
 import pandas as pd
 from dagster import (
     AssetExecutionContext,
     AssetSelection,
-    Config,
     MetadataValue,
     asset,
     define_asset_job,
 )
 
-from aimdl_coord_enrichment import __version__ as PIPELINE_VERSION
-from aimdl_coord_enrichment.constants import ALPSS_RESULT_DATA_TYPE, COLUMN_MAP, PDV_TRACE_DATA_TYPE
-from aimdl_coord_enrichment.coordinates import _COORD_YAML, transform_station_to_sample
-from aimdl_coord_enrichment.girder_io import download_and_read, fetch_all_aimdl_datafiles, nan_to_none
-from aimdl_coord_enrichment.matching import match_pdv_file
-from aimdl_coord_enrichment.provenance import (
-    build_coord_provenance,
-    compute_yaml_sha256,
-    get_transformer_version,
+from aimdl_coord_enrichment.constants import PDV_TRACE_DATA_TYPE
+from aimdl_coord_enrichment.coordinates import _COORD_YAML
+from aimdl_coord_enrichment.girder_io import (
+    download_and_read,
+    fetch_all_aimdl_datafiles,
+    fetch_partition_details,
 )
+from aimdl_coord_enrichment.partitions import (
+    HELIX_EXPERIMENT_LOG_DATA_TYPE,
+    HELIX_EXPERIMENT_LOG_PARTITIONS,
+)
+from aimdl_coord_enrichment.provenance import compute_yaml_sha256, get_transformer_version
 from aimdl_coord_enrichment.resources import GirderConnection
-from aimdl_coord_enrichment.validation import NpEncoder, validate_igsn
+from aimdl_coord_enrichment.spreadsheet import (
+    count_rows_with_pdv,
+    match_pdv_rows,
+    normalize_experiment_log,
+    summarize_pdv_processing,
+    validate_log_rows,
+    write_pdv_metadata,
+    write_processing_manifest,
+)
+
+# Design principle for this module: assets model durable external-state
+# transitions, helpers (spreadsheet.py) do the computation, checks
+# (checks.py) provide validation visibility, and partitions give each
+# spreadsheet its own history/retries/backfills. The flow is three
+# partitioned assets — pdv_log -> pdv_data -> pdv_processing_manifest —
+# partitioned by the AIMD-L logical key "<igsn>//<experiment_date>".
 
 
-class ExperimentLogConfig(Config):
-    item_id: str
-    filename: str
-
-
-@asset(group_name="helix_spreadsheet")
-def experiment_log_source(
+@asset(
+    group_name="helix_spreadsheet",
+    partitions_def=HELIX_EXPERIMENT_LOG_PARTITIONS,
+)
+def pdv_log(
     context: AssetExecutionContext,
-    config: ExperimentLogConfig,
+    girder: GirderConnection,
 ) -> dict:
-    """Emit the spreadsheet source descriptor for this run.
+    """Durable boundary: read the experiment log(s) for one partition.
 
-    This asset is the single Config-bearing entry point for the
-    spreadsheet DAG. Downstream assets that need the source item id
-    or filename consume this value rather than each declaring their
-    own ExperimentLogConfig. Keeps the sensor's RunRequest small and
-    keeps source identity a first-class value in the asset graph.
+    The partition key is the AIMD-L logical key
+    ``"<igsn>//<experiment_date>"``. Fetches the matching
+    ``pdv_experiment_log`` items, downloads + normalizes each into a
+    DataFrame, concatenates them, and validates IGSNs. A partition key
+    may resolve to one or more log items; all are concatenated and every
+    source item id recorded (each row tagged with its origin via the
+    ``_source_item_id`` column).
+
+    Pure computation lives in spreadsheet.py; this asset owns only the
+    Girder reads.
     """
-    source = {"item_id": config.item_id, "filename": config.filename}
-    context.add_output_metadata(
-        {
-            "item_id": MetadataValue.text(config.item_id),
-            "filename": MetadataValue.text(config.filename),
-        }
-    )
-    return source
+    key = context.partition_key
+    items = fetch_partition_details(girder, HELIX_EXPERIMENT_LOG_DATA_TYPE, key)
 
-
-@asset(group_name="helix_spreadsheet")
-def raw_experiment_log(
-    context: AssetExecutionContext,
-    experiment_log_source: dict,
-    girder: GirderConnection,
-) -> pd.DataFrame:
-    """Download a spreadsheet from Girder and apply COLUMN_MAP rename."""
-    item_id = experiment_log_source["item_id"]
-    filename = experiment_log_source["filename"]
-    df = download_and_read(girder, item_id, filename)
-    df = df.rename(columns=COLUMN_MAP)
-    context.add_output_metadata(
-        {
-            "row_count": MetadataValue.int(len(df)),
-            "filename": MetadataValue.text(filename),
-            "source_item_id": MetadataValue.text(item_id),
-        }
-    )
-    return df
-
-
-@asset(group_name="helix_spreadsheet")
-def pdv_trace_inventory(
-    context: AssetExecutionContext,
-    girder: GirderConnection,
-) -> list:
-    """Fetch PDV trace items via the /aimdl/datafiles endpoint.
-
-    Uses an indexed MongoDB query filtered by meta.data_type='pdv_trace'
-    instead of crawling the PDV folder tree. Items must have meta.igsn
-    set to appear in results.
-    """
-    items = fetch_all_aimdl_datafiles(girder, PDV_TRACE_DATA_TYPE)
-
-    igsns = set()
+    frames = []
+    source_item_ids = []
     for item in items:
-        igsn = item.get("meta", {}).get("igsn")
-        if igsn:
-            igsns.add(igsn)
+        item_id = item["_id"]
+        df = download_and_read(girder, item_id, item["name"])
+        df = normalize_experiment_log(df)
+        df["_source_item_id"] = item_id
+        frames.append(df)
+        source_item_ids.append(item_id)
 
-    context.add_output_metadata({
-        "item_count": MetadataValue.int(len(items)),
-        "unique_igsns": MetadataValue.int(len(igsns)),
-        "data_type": MetadataValue.text(PDV_TRACE_DATA_TYPE),
-    })
+    if frames:
+        combined = pd.concat(frames, ignore_index=True)
+    else:
+        combined = pd.DataFrame()
 
-    if len(items) == 0:
-        context.log.warning(
-            "pdv_trace_inventory returned 0 items. This may indicate that "
-            "meta.igsn has not been tagged on PDV files yet."
-        )
-
-    return items
-
-
-@asset(group_name="helix_spreadsheet")
-def validated_rows(
-    context: AssetExecutionContext,
-    raw_experiment_log: pd.DataFrame,
-) -> dict:
-    """Validate IGSNs for each row. Pure transformation, no network calls."""
-    df = raw_experiment_log.copy()
-    igsn_issues = []
-    valid_igsns = []
-
-    for idx, row in df.iterrows():
-        valid_igsn, issue = validate_igsn(row.get("Sample_IGSN"))
-        valid_igsns.append(valid_igsn)
-        if issue is not None:
-            issue["row"] = idx
-            igsn_issues.append(issue)
-
-    df["valid_igsn"] = valid_igsns
-
-    valid_count = sum(1 for v in valid_igsns if v is not None)
-    missing_count = sum(1 for i in igsn_issues if i["issue"] == "missing")
-    invalid_count = sum(1 for i in igsn_issues if i["issue"] == "invalid_format")
+    combined, igsn_issues = validate_log_rows(combined)
 
     context.add_output_metadata(
         {
-            "total_rows": MetadataValue.int(len(df)),
-            "valid_igsn_count": MetadataValue.int(valid_count),
-            "invalid_igsn_count": MetadataValue.int(invalid_count),
-            "missing_igsn_count": MetadataValue.int(missing_count),
+            "partition_key": MetadataValue.text(key),
+            "source_item_count": MetadataValue.int(len(source_item_ids)),
+            "row_count": MetadataValue.int(len(combined)),
+            "igsn_issue_count": MetadataValue.int(len(igsn_issues)),
         }
     )
-    return {"dataframe": df, "igsn_issues": igsn_issues}
+    return {
+        "dataframe": combined,
+        "igsn_issues": igsn_issues,
+        "source_item_ids": source_item_ids,
+        "partition_key": key,
+    }
 
 
-@asset(group_name="helix_spreadsheet")
-def pdv_cross_references(
+@asset(
+    group_name="helix_spreadsheet",
+    partitions_def=HELIX_EXPERIMENT_LOG_PARTITIONS,
+)
+def pdv_data(
     context: AssetExecutionContext,
-    validated_rows: dict,
-    pdv_trace_inventory: list,
-) -> dict:
-    """Match PDV filenames to inventory items. Pure matching, no network calls."""
-    df = validated_rows["dataframe"]
-    matches = {}
-    pdv_issues = []
-
-    for idx, row in df.iterrows():
-        pdv_filename = row.get("PDV_FileName")
-        pdv_item, issue = match_pdv_file(pdv_trace_inventory, pdv_filename)
-        if pdv_item is not None:
-            matches[idx] = pdv_item
-            # Cross-check IGSN consistency
-            row_igsn = row.get("valid_igsn")
-            item_igsn = pdv_item.get("meta", {}).get("igsn")
-            if row_igsn and item_igsn and row_igsn != item_igsn:
-                pdv_issues.append({
-                    "pdv_filename": pdv_filename,
-                    "type": "igsn_mismatch",
-                    "row": idx,
-                    "spreadsheet_igsn": row_igsn,
-                    "item_igsn": item_igsn,
-                })
-        if issue is not None:
-            issue["row"] = idx
-            pdv_issues.append(issue)
-
-    matched_count = len(matches)
-    not_found_count = sum(1 for i in pdv_issues if i["type"] == "not_found")
-    ambiguous_count = sum(1 for i in pdv_issues if i["type"] == "ambiguous")
-
-    mismatch_count = sum(1 for i in pdv_issues if i["type"] == "igsn_mismatch")
-
-    context.add_output_metadata(
-        {
-            "matched_count": MetadataValue.int(matched_count),
-            "not_found_count": MetadataValue.int(not_found_count),
-            "ambiguous_count": MetadataValue.int(ambiguous_count),
-            "igsn_mismatch_count": MetadataValue.int(mismatch_count),
-        }
-    )
-    return {"matches": matches, "pdv_issues": pdv_issues}
-
-
-@asset(group_name="helix_spreadsheet")
-def enriched_pdv_metadata(
-    context: AssetExecutionContext,
-    experiment_log_source: dict,
-    pdv_cross_references: dict,
-    validated_rows: dict,
+    pdv_log: dict,
     girder: GirderConnection,
 ) -> dict:
-    """Write coordinate and flyer position metadata to matched Girder PDV items.
+    """Durable boundary: match PDV traces and write coordinate metadata.
 
-    For each matched PDV item, writes: Flyer_Row, Flyer_Column,
-    Station_X, Station_Y (instrument coordinates), Sample_X, Sample_Y
-    (transformed sample-frame coordinates), and a coord_provenance
-    block describing the transform version, YAML digest, shot
-    timestamp, and source spreadsheet row used.
+    Fetches the full ``pdv_trace`` inventory (indexed /aimdl/datafiles
+    query), matches each log row by PDV_FileName prefix, then writes
+    Station/Sample coordinates + coord_provenance to each matched Girder
+    item. Returns one dict bundling everything the five attached checks
+    need.
     """
-    df = validated_rows["dataframe"]
-    matches = pdv_cross_references["matches"]
+    df = pdv_log["dataframe"]
+    source_item_ids = pdv_log["source_item_ids"]
+
+    inventory = fetch_all_aimdl_datafiles(girder, PDV_TRACE_DATA_TYPE)
+    matches, pdv_issues = match_pdv_rows(df, inventory)
 
     try:
         yaml_sha256 = compute_yaml_sha256(_COORD_YAML)
@@ -219,107 +128,39 @@ def enriched_pdv_metadata(
         )
         yaml_sha256 = None
     transformer_version = get_transformer_version()
-    naive_timestamps_count = 0
-    version_counter: dict[str, int] = {}
 
     try:
         run_id = context.run.run_id
     except Exception:
         run_id = None
 
-    def _parse_row_timestamp(raw):
-        """Return (tz-aware datetime or None, was_naive: bool, origin: str)."""
-        if raw is None:
-            return None, False, "missing"
-        try:
-            ts = pd.to_datetime(raw)
-        except (ValueError, TypeError):
-            return None, False, "unparseable"
-        if pd.isna(ts):
-            return None, False, "missing"
-        py_ts = ts.to_pydatetime()
-        if py_ts.tzinfo is None:
-            py_ts = py_ts.replace(tzinfo=timezone.utc)
-            return py_ts, True, "spreadsheet_timestamp_col_assumed_utc"
-        return py_ts, False, "spreadsheet_timestamp_col"
+    write_summary = write_pdv_metadata(
+        girder,
+        df,
+        matches,
+        run_id=run_id,
+        source_item_id=source_item_ids[0] if source_item_ids else None,
+        yaml_sha256=yaml_sha256,
+        transformer_version=transformer_version,
+    )
 
-    written_count = 0
-    write_errors = []
-    coord_failures = 0
-
-    for row_idx, pdv_item in matches.items():
-        row = df.loc[row_idx]
-
-        station_x = nan_to_none(row.get("Flyer_X_Position_Final_mm"))
-        station_y = nan_to_none(row.get("Flyer_Y_Position_Final_mm"))
-        shot_ts, was_naive, ts_origin = _parse_row_timestamp(row.get("Timestamp"))
-        if was_naive:
-            naive_timestamps_count += 1
-        sample_x, sample_y, transform_name = transform_station_to_sample(
-            station_x, station_y, timestamp=shot_ts
-        )
-        if transform_name is not None:
-            version_counter[transform_name] = version_counter.get(transform_name, 0) + 1
-        # ensure that sample_x,y have only 4 meaningful digits to avoid bogus precision
-        if sample_x is not None:
-            sample_x = round(sample_x, 4)
-        if sample_y is not None:
-            sample_y = round(sample_y, 4)
-
-        if station_x is not None and station_y is not None and sample_x is None:
-            coord_failures += 1
-
-        coord_prov = build_coord_provenance(
-            instrument="HELIX",
-            transform_version=transform_name,
-            transform_yaml_sha256=yaml_sha256 or "",
-            transformer_version=transformer_version,
-            pipeline_version=PIPELINE_VERSION,
-            source_timestamp=shot_ts,
-            source_timestamp_origin=ts_origin,
-            station_coord_source={
-                "kind": "helix_experiment_log",
-                "spreadsheet_item_id": experiment_log_source["item_id"],
-                "spreadsheet_row_index": int(row_idx),
-                "spreadsheet_pdv_filename": row.get("PDV_FileName"),
-            },
-            dagster_run_id=run_id,
-        )
-
-        metadata = {
-            "Flyer_Row": nan_to_none(row.get("Flyer_Row")),
-            "Flyer_Column": nan_to_none(row.get("Flyer_Column")),
-            "Station_X": station_x,
-            "Station_Y": station_y,
-            "Sample_X": sample_x,
-            "Sample_Y": sample_y,
-            "coord_provenance": coord_prov,
-        }
-        # Ensure all values are JSON-serializable
-        metadata = json.loads(json.dumps(metadata, cls=NpEncoder))
-
-        try:
-            girder.addMetadataToItem(pdv_item["_id"], metadata)
-            written_count += 1
-        except Exception as exc:
-            context.log.error(
-                f"Failed to write metadata for row {row_idx}, item {pdv_item['_id']}: {exc}"
-            )
-            write_errors.append({"row": row_idx, "error": str(exc)})
-
-    if naive_timestamps_count > 0:
+    if write_summary["naive_timestamps_count"] > 0:
         context.log.warning(
             "Spreadsheet contained %d naive Timestamp values; "
             "interpreted as UTC. Set an explicit timezone in the "
             "station export to remove this ambiguity.",
-            naive_timestamps_count,
+            write_summary["naive_timestamps_count"],
         )
 
+    version_counter = write_summary["version_counter"]
     context.add_output_metadata(
         {
-            "items_enriched": MetadataValue.int(written_count),
-            "coordinate_transform_failures": MetadataValue.int(coord_failures),
-            "naive_timestamps": MetadataValue.int(naive_timestamps_count),
+            "inventory_count": MetadataValue.int(len(inventory)),
+            "matched_count": MetadataValue.int(len(matches)),
+            "items_enriched": MetadataValue.int(write_summary["written_count"]),
+            "coordinate_transform_failures": MetadataValue.int(
+                write_summary["coord_failures"]
+            ),
             "transform_versions_used": MetadataValue.text(
                 ", ".join(f"{k}={v}" for k, v in sorted(version_counter.items()))
                 or "none"
@@ -327,202 +168,78 @@ def enriched_pdv_metadata(
         }
     )
     return {
-        "written_count": written_count,
-        "write_errors": write_errors,
-        "coord_failures": coord_failures,
-        "version_counter": version_counter,
-        "naive_timestamps_count": naive_timestamps_count,
-        "yaml_sha256": yaml_sha256,
-    }
-
-
-@asset(group_name="helix_spreadsheet")
-def alpss_results_inventory(
-    context: AssetExecutionContext,
-    girder: GirderConnection,
-) -> list:
-    """Fetch ALPSS result items via the /aimdl/datafiles endpoint.
-
-    Returns items with meta.data_type='pdv_alpss_result'. Used for
-    quality reporting on ALPSS processing completeness.
-    """
-    items = fetch_all_aimdl_datafiles(girder, ALPSS_RESULT_DATA_TYPE)
-
-    igsns = set()
-    for item in items:
-        igsn = item.get("meta", {}).get("igsn")
-        if igsn:
-            igsns.add(igsn)
-
-    context.add_output_metadata({
-        "item_count": MetadataValue.int(len(items)),
-        "unique_igsns": MetadataValue.int(len(igsns)),
-        "data_type": MetadataValue.text(ALPSS_RESULT_DATA_TYPE),
-    })
-    return items
-
-
-@asset(group_name="helix_spreadsheet")
-def quality_report(
-    context: AssetExecutionContext,
-    validated_rows: dict,
-    pdv_cross_references: dict,
-    enriched_pdv_metadata: dict,
-    alpss_results_inventory: list,
-) -> dict:
-    """Aggregate all issues and ALPSS completeness metrics."""
-    igsn_issues = validated_rows["igsn_issues"]
-    pdv_issues = pdv_cross_references["pdv_issues"]
-    write_errors = enriched_pdv_metadata["write_errors"]
-    matches = pdv_cross_references["matches"]
-
-    # ALPSS completeness: which matched PDV traces have ALPSS results?
-    alpss_igsns = set()
-    for item in alpss_results_inventory:
-        igsn = item.get("meta", {}).get("igsn")
-        if igsn:
-            alpss_igsns.add(igsn)
-
-    matched_igsns = set()
-    df = validated_rows["dataframe"]
-    for row_idx in matches:
-        row_igsn = df.loc[row_idx].get("valid_igsn")
-        if row_igsn:
-            matched_igsns.add(row_igsn)
-
-    igsns_with_alpss = matched_igsns & alpss_igsns
-    igsns_without_alpss = matched_igsns - alpss_igsns
-
-    report = {
-        "igsn_issues": igsn_issues,
+        "inventory_count": len(inventory),
+        "matched_count": len(matches),
+        "rows_with_pdv": count_rows_with_pdv(df),
         "pdv_issues": pdv_issues,
-        "write_errors": write_errors,
-        "alpss_completeness": {
-            "matched_igsns": len(matched_igsns),
-            "igsns_with_alpss_results": len(igsns_with_alpss),
-            "igsns_without_alpss_results": len(igsns_without_alpss),
-            "missing_igsns": sorted(igsns_without_alpss),
-        },
-        "summary": {
-            "total_igsn_issues": len(igsn_issues),
-            "total_pdv_issues": len(pdv_issues),
-            "total_write_errors": len(write_errors),
-            "alpss_coverage_pct": (
-                round(100 * len(igsns_with_alpss) / len(matched_igsns), 1)
-                if matched_igsns else 0.0
-            ),
-        },
+        "written_count": write_summary["written_count"],
+        "write_errors": write_summary["write_errors"],
+        "coord_failures": write_summary["coord_failures"],
+        "version_counter": version_counter,
+        "yaml_sha256": yaml_sha256,
+        "naive_timestamps_count": write_summary["naive_timestamps_count"],
     }
 
-    context.add_output_metadata({
-        "total_igsn_issues": MetadataValue.int(len(igsn_issues)),
-        "total_pdv_issues": MetadataValue.int(len(pdv_issues)),
-        "total_write_errors": MetadataValue.int(len(write_errors)),
-        "alpss_coverage_pct": MetadataValue.float(
-            report["summary"]["alpss_coverage_pct"]
-        ),
-        "igsns_without_alpss": MetadataValue.int(len(igsns_without_alpss)),
-    })
-    return report
 
-
-@asset(group_name="helix_spreadsheet")
-def processing_manifest(
+@asset(
+    group_name="helix_spreadsheet",
+    partitions_def=HELIX_EXPERIMENT_LOG_PARTITIONS,
+)
+def pdv_processing_manifest(
     context: AssetExecutionContext,
-    experiment_log_source: dict,
-    quality_report: dict,
-    validated_rows: dict,
-    pdv_cross_references: dict,
-    enriched_pdv_metadata: dict,
+    pdv_log: dict,
+    pdv_data: dict,
     girder: GirderConnection,
 ) -> dict:
-    """Write a processing status record to the source spreadsheet's Girder item.
+    """Durable boundary: write meta.processing_status to source log item(s).
 
-    This provides:
-    - Audit trail: persistent record of what the pipeline did
-    - Idempotency: sensor can check before triggering reruns
-    - Cross-system visibility: Girder UI shows processing status
+    Summarizes the run's issues and writes a processing manifest back to
+    each source ``pdv_experiment_log`` Girder item, giving an audit
+    trail, sensor idempotency, and cross-system visibility.
+    ``manifest_written`` is False if any per-item write failed.
     """
-    item_id = experiment_log_source["item_id"]
-    df = validated_rows["dataframe"]
-    total_rows = len(df)
-    valid_igsn_count = int(df["valid_igsn"].notna().sum())
-    matched_count = len(pdv_cross_references["matches"])
-    written_count = enriched_pdv_metadata["written_count"]
-    coord_failures = enriched_pdv_metadata.get("coord_failures", 0)
-
-    igsn_issues = validated_rows["igsn_issues"]
-    pdv_issues = pdv_cross_references["pdv_issues"]
-    write_errors = enriched_pdv_metadata["write_errors"]
-
-    issues_summary = {
-        "igsn_invalid": sum(1 for i in igsn_issues if i.get("issue") == "invalid_format"),
-        "igsn_missing": sum(1 for i in igsn_issues if i.get("issue") == "missing"),
-        "pdv_not_found": sum(1 for i in pdv_issues if i.get("type") == "not_found"),
-        "pdv_ambiguous": sum(1 for i in pdv_issues if i.get("type") == "ambiguous"),
-        "igsn_mismatch": sum(1 for i in pdv_issues if i.get("type") == "igsn_mismatch"),
-        "write_errors": len(write_errors),
-        "coord_failures": coord_failures,
-    }
-
-    has_issues = any(v > 0 for v in issues_summary.values())
-    status = "completed_with_warnings" if has_issues else "completed_clean"
+    summary = summarize_pdv_processing(pdv_log, pdv_data)
 
     try:
         run_id = context.run.run_id
     except Exception:
         run_id = "direct-invocation"
 
-    manifest = {
-        "last_processed": datetime.now(timezone.utc).isoformat(),
-        "dagster_run_id": run_id,
-        "pipeline_version": PIPELINE_VERSION,
-        "total_rows": total_rows,
-        "rows_valid_igsn": valid_igsn_count,
-        "rows_matched_pdv": matched_count,
-        "rows_enriched": written_count,
-        "status": status,
-        "issues_summary": issues_summary,
+    source_item_ids = pdv_log["source_item_ids"]
+    write_failed = False
+    for item_id in source_item_ids:
+        manifest = write_processing_manifest(
+            girder, item_id, summary, run_id=run_id
+        )
+        if manifest.get("write_failed"):
+            write_failed = True
+
+    manifest_written = bool(source_item_ids) and not write_failed
+
+    context.add_output_metadata(
+        {
+            "status": MetadataValue.text(summary["status"]),
+            "manifest_written": MetadataValue.bool(manifest_written),
+            "source_item_count": MetadataValue.int(len(source_item_ids)),
+            "rows_enriched": MetadataValue.int(summary["rows_enriched"]),
+        }
+    )
+    return {
+        "status": summary["status"],
+        "manifest_written": manifest_written,
+        "issues_summary": summary["issues_summary"],
+        "total_rows": summary["total_rows"],
+        "rows_valid_igsn": summary["rows_valid_igsn"],
+        "rows_matched_pdv": summary["rows_matched_pdv"],
+        "rows_enriched": summary["rows_enriched"],
     }
-
-    # Write to the source spreadsheet's Girder item
-    try:
-        girder.addMetadataToItem(item_id, {"processing_status": manifest})
-        context.log.info(
-            "Wrote processing manifest to Girder item %s: status=%s",
-            item_id,
-            status,
-        )
-    except Exception as exc:
-        context.log.error(
-            "Failed to write processing manifest to Girder item %s: %s",
-            item_id,
-            exc,
-        )
-        manifest["write_failed"] = True
-
-    context.add_output_metadata({
-        "status": MetadataValue.text(status),
-        "total_rows": MetadataValue.int(total_rows),
-        "rows_enriched": MetadataValue.int(written_count),
-        "has_issues": MetadataValue.bool(has_issues),
-        "source_item_id": MetadataValue.text(item_id),
-    })
-
-    return manifest
 
 
 process_helix_assets_job = define_asset_job(
     name="process_helix_assets_job",
     selection=AssetSelection.assets(
-        experiment_log_source,
-        raw_experiment_log,
-        pdv_trace_inventory,
-        validated_rows,
-        pdv_cross_references,
-        enriched_pdv_metadata,
-        alpss_results_inventory,
-        quality_report,
-        processing_manifest,
+        pdv_log,
+        pdv_data,
+        pdv_processing_manifest,
     ),
 )

--- a/aimdl_coord_enrichment/assets.py
+++ b/aimdl_coord_enrichment/assets.py
@@ -2,6 +2,7 @@ import pandas as pd
 from dagster import (
     AssetExecutionContext,
     AssetSelection,
+    Config,
     MetadataValue,
     asset,
     define_asset_job,
@@ -36,6 +37,20 @@ from aimdl_coord_enrichment.spreadsheet import (
 # spreadsheet its own history/retries/backfills. The flow is three
 # partitioned assets — pdv_log -> pdv_data -> pdv_processing_manifest —
 # partitioned by the AIMD-L logical key "<igsn>//<experiment_date>".
+
+
+class HelixSpreadsheetConfig(Config):
+    """Run-time configuration for the helix_spreadsheet writing assets.
+
+    dry_run — if True (default), pdv_data and pdv_processing_manifest
+              perform all reads and compute the would-be Girder writes
+              but skip the actual PUTs. Mirrors the coord_enrichment
+              dry_run convention so a sweep can be rehearsed against
+              production data without mutating it. Set False for a live
+              run.
+    """
+
+    dry_run: bool = True
 
 
 @asset(
@@ -101,6 +116,7 @@ def pdv_log(
 )
 def pdv_data(
     context: AssetExecutionContext,
+    config: HelixSpreadsheetConfig,
     pdv_log: dict,
     girder: GirderConnection,
 ) -> dict:
@@ -109,8 +125,9 @@ def pdv_data(
     Fetches the full ``pdv_trace`` inventory (indexed /aimdl/datafiles
     query), matches each log row by PDV_FileName prefix, then writes
     Station/Sample coordinates + coord_provenance to each matched Girder
-    item. Returns one dict bundling everything the five attached checks
-    need.
+    item. With ``config.dry_run`` True (the default) the writes are
+    simulated, not performed. Returns one dict bundling everything the
+    attached checks need.
     """
     df = pdv_log["dataframe"]
     source_item_ids = pdv_log["source_item_ids"]
@@ -142,6 +159,7 @@ def pdv_data(
         source_item_id=source_item_ids[0] if source_item_ids else None,
         yaml_sha256=yaml_sha256,
         transformer_version=transformer_version,
+        dry_run=config.dry_run,
     )
 
     if write_summary["naive_timestamps_count"] > 0:
@@ -152,12 +170,21 @@ def pdv_data(
             write_summary["naive_timestamps_count"],
         )
 
+    if config.dry_run:
+        context.log.info(
+            "DRY RUN — would have written coordinate metadata to %d "
+            "matched pdv_trace item(s); no Girder writes performed.",
+            write_summary["simulated_count"],
+        )
+
     version_counter = write_summary["version_counter"]
     context.add_output_metadata(
         {
+            "dry_run": MetadataValue.bool(config.dry_run),
             "inventory_count": MetadataValue.int(len(inventory)),
             "matched_count": MetadataValue.int(len(matches)),
             "items_enriched": MetadataValue.int(write_summary["written_count"]),
+            "items_simulated": MetadataValue.int(write_summary["simulated_count"]),
             "coordinate_transform_failures": MetadataValue.int(
                 write_summary["coord_failures"]
             ),
@@ -168,11 +195,13 @@ def pdv_data(
         }
     )
     return {
+        "dry_run": config.dry_run,
         "inventory_count": len(inventory),
         "matched_count": len(matches),
         "rows_with_pdv": count_rows_with_pdv(df),
         "pdv_issues": pdv_issues,
         "written_count": write_summary["written_count"],
+        "simulated_count": write_summary["simulated_count"],
         "write_errors": write_summary["write_errors"],
         "coord_failures": write_summary["coord_failures"],
         "version_counter": version_counter,
@@ -187,6 +216,7 @@ def pdv_data(
 )
 def pdv_processing_manifest(
     context: AssetExecutionContext,
+    config: HelixSpreadsheetConfig,
     pdv_log: dict,
     pdv_data: dict,
     girder: GirderConnection,
@@ -195,8 +225,10 @@ def pdv_processing_manifest(
 
     Summarizes the run's issues and writes a processing manifest back to
     each source ``pdv_experiment_log`` Girder item, giving an audit
-    trail, sensor idempotency, and cross-system visibility.
-    ``manifest_written`` is False if any per-item write failed.
+    trail, sensor idempotency, and cross-system visibility. With
+    ``config.dry_run`` True (the default) the manifest is computed but
+    not written. ``manifest_written`` is False only if a real per-item
+    write failed.
     """
     summary = summarize_pdv_processing(pdv_log, pdv_data)
 
@@ -209,15 +241,23 @@ def pdv_processing_manifest(
     write_failed = False
     for item_id in source_item_ids:
         manifest = write_processing_manifest(
-            girder, item_id, summary, run_id=run_id
+            girder, item_id, summary, run_id=run_id, dry_run=config.dry_run
         )
         if manifest.get("write_failed"):
             write_failed = True
 
     manifest_written = bool(source_item_ids) and not write_failed
 
+    if config.dry_run:
+        context.log.info(
+            "DRY RUN — would have written meta.processing_status to %d "
+            "source log item(s); no Girder writes performed.",
+            len(source_item_ids),
+        )
+
     context.add_output_metadata(
         {
+            "dry_run": MetadataValue.bool(config.dry_run),
             "status": MetadataValue.text(summary["status"]),
             "manifest_written": MetadataValue.bool(manifest_written),
             "source_item_count": MetadataValue.int(len(source_item_ids)),
@@ -225,6 +265,7 @@ def pdv_processing_manifest(
         }
     )
     return {
+        "dry_run": config.dry_run,
         "status": summary["status"],
         "manifest_written": manifest_written,
         "issues_summary": summary["issues_summary"],

--- a/aimdl_coord_enrichment/checks.py
+++ b/aimdl_coord_enrichment/checks.py
@@ -104,10 +104,16 @@ def igsn_consistency(context, pdv_data):
 
 @asset_check(asset="pdv_data")
 def enrichment_success_rate(context, pdv_data):
-    """WARN if fewer than 90% of matched items were successfully enriched."""
+    """WARN if fewer than 90% of matched items were successfully enriched.
+
+    Counts dry-run simulated writes as successes so a rehearsal reads as
+    representative of a live run.
+    """
     matched_count = pdv_data["matched_count"]
     written_count = pdv_data["written_count"]
-    rate = written_count / matched_count if matched_count > 0 else 0.0
+    simulated_count = pdv_data.get("simulated_count", 0)
+    success = written_count + simulated_count
+    rate = success / matched_count if matched_count > 0 else 0.0
     error_count = len(pdv_data["write_errors"])
     passed = rate >= 0.9
     return AssetCheckResult(
@@ -116,10 +122,11 @@ def enrichment_success_rate(context, pdv_data):
         metadata={
             "matched_count": matched_count,
             "written_count": written_count,
+            "simulated_count": simulated_count,
             "error_count": error_count,
             "success_rate": round(rate, 3),
         },
-        description=f"Enrichment success rate: {rate:.1%} ({written_count}/{matched_count})",
+        description=f"Enrichment success rate: {rate:.1%} ({success}/{matched_count})",
     )
 
 
@@ -135,9 +142,9 @@ def coord_transform_check(context, pdv_data):
     failures = pdv_data.get("coord_failures", 0)
     version_counter = pdv_data.get("version_counter", {}) or {}
     yaml_sha256 = pdv_data.get("yaml_sha256")
-    written_count = pdv_data.get("written_count", 0)
+    attempted = pdv_data.get("written_count", 0) + pdv_data.get("simulated_count", 0)
 
-    unresolved_versions = written_count > 0 and not version_counter
+    unresolved_versions = attempted > 0 and not version_counter
     missing_sha = yaml_sha256 is None
 
     passed = (failures == 0) and (not unresolved_versions) and (not missing_sha)

--- a/aimdl_coord_enrichment/checks.py
+++ b/aimdl_coord_enrichment/checks.py
@@ -2,42 +2,21 @@
 
 These checks evaluate the output of each critical asset and produce
 pass/warn/fail indicators visible in the Dagster UI. They do NOT block
-pipeline execution — they are advisory.
+pipeline execution — they are advisory. Each check reads a single
+asset's bundled output dict.
 """
 
 from dagster import (
     AssetCheckResult,
     AssetCheckSeverity,
-    AssetIn,
     asset_check,
 )
 
 
-@asset_check(asset="pdv_trace_inventory")
-def zero_inventory(context, pdv_trace_inventory):
-    """ERROR if the PDV trace inventory returned zero items.
-
-    This typically means meta.igsn has not been tagged on PDV files yet,
-    so the /aimdl/datafiles endpoint returns nothing.
-    """
-    count = len(pdv_trace_inventory)
-    passed = count > 0
-    return AssetCheckResult(
-        passed=passed,
-        severity=AssetCheckSeverity.ERROR,
-        metadata={"item_count": count},
-        description=(
-            f"Inventory contains {count} items."
-            if passed
-            else "Inventory is EMPTY. Check that meta.igsn is tagged on PDV files."
-        ),
-    )
-
-
-@asset_check(asset="validated_rows")
-def igsn_validity_rate(context, validated_rows):
+@asset_check(asset="pdv_log")
+def igsn_validity_rate(context, pdv_log):
     """WARN if fewer than 80% of rows have valid IGSNs."""
-    df = validated_rows["dataframe"]
+    df = pdv_log["dataframe"]
     total = len(df)
     if total == 0:
         return AssetCheckResult(
@@ -61,19 +40,32 @@ def igsn_validity_rate(context, validated_rows):
     )
 
 
-@asset_check(asset="pdv_cross_references", additional_ins={"validated_rows": AssetIn("validated_rows")})
-def pdv_match_rate(context, pdv_cross_references, validated_rows):
-    """WARN if fewer than 50% of rows with PDV filenames were matched."""
-    df = validated_rows["dataframe"]
-    import math
-    rows_with_pdv = sum(
-        1
-        for _, row in df.iterrows()
-        if row.get("PDV_FileName") is not None
-        and not (isinstance(row.get("PDV_FileName"), float) and math.isnan(row.get("PDV_FileName")))
-        and str(row.get("PDV_FileName")).strip() != ""
+@asset_check(asset="pdv_data")
+def zero_pdv_inventory(context, pdv_data):
+    """ERROR if the PDV trace inventory returned zero items.
+
+    This typically means meta.igsn has not been tagged on PDV files yet,
+    so the /aimdl/datafiles endpoint returns nothing.
+    """
+    count = pdv_data["inventory_count"]
+    passed = count > 0
+    return AssetCheckResult(
+        passed=passed,
+        severity=AssetCheckSeverity.ERROR,
+        metadata={"item_count": count},
+        description=(
+            f"Inventory contains {count} items."
+            if passed
+            else "Inventory is EMPTY. Check that meta.igsn is tagged on PDV files."
+        ),
     )
-    matched_count = len(pdv_cross_references["matches"])
+
+
+@asset_check(asset="pdv_data")
+def pdv_match_rate(context, pdv_data):
+    """WARN if fewer than 50% of rows with PDV filenames were matched."""
+    rows_with_pdv = pdv_data["rows_with_pdv"]
+    matched_count = pdv_data["matched_count"]
     rate = matched_count / rows_with_pdv if rows_with_pdv > 0 else 0.0
     passed = rate >= 0.5
     return AssetCheckResult(
@@ -88,10 +80,10 @@ def pdv_match_rate(context, pdv_cross_references, validated_rows):
     )
 
 
-@asset_check(asset="pdv_cross_references")
-def igsn_consistency(context, pdv_cross_references):
+@asset_check(asset="pdv_data")
+def igsn_consistency(context, pdv_data):
     """ERROR if any matched PDV item has a different IGSN than the spreadsheet row."""
-    issues = pdv_cross_references["pdv_issues"]
+    issues = pdv_data["pdv_issues"]
     mismatches = [i for i in issues if i.get("type") == "igsn_mismatch"]
     passed = len(mismatches) == 0
     metadata = {"mismatch_count": len(mismatches)}
@@ -110,13 +102,13 @@ def igsn_consistency(context, pdv_cross_references):
     )
 
 
-@asset_check(asset="enriched_pdv_metadata", additional_ins={"pdv_cross_references": AssetIn("pdv_cross_references")})
-def enrichment_success_rate(context, enriched_pdv_metadata, pdv_cross_references):
+@asset_check(asset="pdv_data")
+def enrichment_success_rate(context, pdv_data):
     """WARN if fewer than 90% of matched items were successfully enriched."""
-    matched_count = len(pdv_cross_references["matches"])
-    written_count = enriched_pdv_metadata["written_count"]
+    matched_count = pdv_data["matched_count"]
+    written_count = pdv_data["written_count"]
     rate = written_count / matched_count if matched_count > 0 else 0.0
-    error_count = len(enriched_pdv_metadata["write_errors"])
+    error_count = len(pdv_data["write_errors"])
     passed = rate >= 0.9
     return AssetCheckResult(
         passed=passed,
@@ -131,8 +123,8 @@ def enrichment_success_rate(context, enriched_pdv_metadata, pdv_cross_references
     )
 
 
-@asset_check(asset="enriched_pdv_metadata")
-def coord_transform_check(context, enriched_pdv_metadata):
+@asset_check(asset="pdv_data")
+def coord_transform_check(context, pdv_data):
     """WARN on coordinate transform issues.
 
     Fails (WARN) if any of:
@@ -140,10 +132,10 @@ def coord_transform_check(context, enriched_pdv_metadata):
       - version_counter is empty while writes happened
       - yaml_sha256 is None         (YAML could not be hashed)
     """
-    failures = enriched_pdv_metadata.get("coord_failures", 0)
-    version_counter = enriched_pdv_metadata.get("version_counter", {}) or {}
-    yaml_sha256 = enriched_pdv_metadata.get("yaml_sha256")
-    written_count = enriched_pdv_metadata.get("written_count", 0)
+    failures = pdv_data.get("coord_failures", 0)
+    version_counter = pdv_data.get("version_counter", {}) or {}
+    yaml_sha256 = pdv_data.get("yaml_sha256")
+    written_count = pdv_data.get("written_count", 0)
 
     unresolved_versions = written_count > 0 and not version_counter
     missing_sha = yaml_sha256 is None
@@ -172,4 +164,20 @@ def coord_transform_check(context, enriched_pdv_metadata):
             "yaml_sha256_present": not missing_sha,
         },
         description=description,
+    )
+
+
+@asset_check(asset="pdv_processing_manifest")
+def manifest_written(context, pdv_processing_manifest):
+    """ERROR if the processing manifest was not written to any source item."""
+    written = pdv_processing_manifest.get("manifest_written", False)
+    return AssetCheckResult(
+        passed=bool(written),
+        severity=AssetCheckSeverity.ERROR,
+        metadata={"status": pdv_processing_manifest.get("status", "unknown")},
+        description=(
+            "Processing manifest written to source log item(s)."
+            if written
+            else "Processing manifest write FAILED for one or more source items."
+        ),
     )

--- a/aimdl_coord_enrichment/checks.py
+++ b/aimdl_coord_enrichment/checks.py
@@ -1,9 +1,17 @@
 """Dagster asset checks for data quality surfacing.
 
-These checks evaluate the output of each critical asset and produce
-pass/warn/fail indicators visible in the Dagster UI. They do NOT block
-pipeline execution — they are advisory. Each check reads a single
-asset's bundled output dict.
+These checks evaluate the output of each helix_spreadsheet asset and
+produce pass/warn/fail indicators visible in the Dagster UI. They do NOT
+block pipeline execution — they are advisory.
+
+The assets are partitioned, so the checks must NOT take their asset as a
+positional input: that would force the IOManager to load the asset by
+partition key, which fails across the dynamic-partition cross-product
+(FileNotFoundError). Instead each check reads its partition's latest
+materialization metadata from the event log via
+``latest_partition_metadata`` and applies a pure decision helper. This
+mirrors the coord_enrichment leaf checks (see
+``coord_enrichment/check_support.py``).
 """
 
 from dagster import (
@@ -12,12 +20,18 @@ from dagster import (
     asset_check,
 )
 
+from aimdl_coord_enrichment.coord_enrichment.check_support import (
+    latest_partition_metadata,
+    no_materialization_result,
+)
 
-@asset_check(asset="pdv_log")
-def igsn_validity_rate(context, pdv_log):
+
+# --- pure decision helpers (unit-tested directly with a flat metadata dict) ---
+
+
+def eval_igsn_validity(md):
     """WARN if fewer than 80% of rows have valid IGSNs."""
-    df = pdv_log["dataframe"]
-    total = len(df)
+    total = int(md.get("row_count", 0))
     if total == 0:
         return AssetCheckResult(
             passed=True,
@@ -25,29 +39,23 @@ def igsn_validity_rate(context, pdv_log):
             metadata={"total_rows": 0, "validity_rate": 0.0},
             description="No rows to validate.",
         )
-    valid_count = df["valid_igsn"].notna().sum()
+    valid_count = int(md.get("valid_igsn_count", 0))
     rate = valid_count / total
-    passed = bool(rate >= 0.8)
     return AssetCheckResult(
-        passed=passed,
+        passed=bool(rate >= 0.8),
         severity=AssetCheckSeverity.WARN,
         metadata={
             "total_rows": total,
-            "valid_count": int(valid_count),
+            "valid_count": valid_count,
             "validity_rate": round(float(rate), 3),
         },
         description=f"IGSN validity rate: {rate:.1%} ({valid_count}/{total})",
     )
 
 
-@asset_check(asset="pdv_data")
-def zero_pdv_inventory(context, pdv_data):
-    """ERROR if the PDV trace inventory returned zero items.
-
-    This typically means meta.igsn has not been tagged on PDV files yet,
-    so the /aimdl/datafiles endpoint returns nothing.
-    """
-    count = pdv_data["inventory_count"]
+def eval_zero_inventory(md):
+    """ERROR if the PDV trace inventory returned zero items."""
+    count = int(md.get("inventory_count", 0))
     passed = count > 0
     return AssetCheckResult(
         passed=passed,
@@ -61,15 +69,13 @@ def zero_pdv_inventory(context, pdv_data):
     )
 
 
-@asset_check(asset="pdv_data")
-def pdv_match_rate(context, pdv_data):
+def eval_pdv_match_rate(md):
     """WARN if fewer than 50% of rows with PDV filenames were matched."""
-    rows_with_pdv = pdv_data["rows_with_pdv"]
-    matched_count = pdv_data["matched_count"]
+    rows_with_pdv = int(md.get("rows_with_pdv", 0))
+    matched_count = int(md.get("matched_count", 0))
     rate = matched_count / rows_with_pdv if rows_with_pdv > 0 else 0.0
-    passed = rate >= 0.5
     return AssetCheckResult(
-        passed=passed,
+        passed=rate >= 0.5,
         severity=AssetCheckSeverity.WARN,
         metadata={
             "rows_with_pdv_filename": rows_with_pdv,
@@ -80,72 +86,59 @@ def pdv_match_rate(context, pdv_data):
     )
 
 
-@asset_check(asset="pdv_data")
-def igsn_consistency(context, pdv_data):
-    """ERROR if any matched PDV item has a different IGSN than the spreadsheet row."""
-    issues = pdv_data["pdv_issues"]
-    mismatches = [i for i in issues if i.get("type") == "igsn_mismatch"]
-    passed = len(mismatches) == 0
-    metadata = {"mismatch_count": len(mismatches)}
-    if mismatches:
-        examples = mismatches[:3]
-        metadata["examples"] = str(examples)
+def eval_igsn_consistency(md):
+    """ERROR if any matched PDV item has a different IGSN than the row."""
+    mismatch_count = int(md.get("igsn_mismatch_count", 0))
+    passed = mismatch_count == 0
     return AssetCheckResult(
         passed=passed,
         severity=AssetCheckSeverity.ERROR,
-        metadata=metadata,
+        metadata={"mismatch_count": mismatch_count},
         description=(
             "No IGSN mismatches."
             if passed
-            else f"{len(mismatches)} IGSN mismatch(es) between spreadsheet and Girder items."
+            else f"{mismatch_count} IGSN mismatch(es) between spreadsheet and Girder items."
         ),
     )
 
 
-@asset_check(asset="pdv_data")
-def enrichment_success_rate(context, pdv_data):
+def eval_enrichment_success_rate(md):
     """WARN if fewer than 90% of matched items were successfully enriched.
 
     Counts dry-run simulated writes as successes so a rehearsal reads as
     representative of a live run.
     """
-    matched_count = pdv_data["matched_count"]
-    written_count = pdv_data["written_count"]
-    simulated_count = pdv_data.get("simulated_count", 0)
-    success = written_count + simulated_count
+    matched_count = int(md.get("matched_count", 0))
+    success = int(md.get("items_enriched", 0)) + int(md.get("items_simulated", 0))
     rate = success / matched_count if matched_count > 0 else 0.0
-    error_count = len(pdv_data["write_errors"])
-    passed = rate >= 0.9
     return AssetCheckResult(
-        passed=passed,
+        passed=rate >= 0.9,
         severity=AssetCheckSeverity.WARN,
         metadata={
             "matched_count": matched_count,
-            "written_count": written_count,
-            "simulated_count": simulated_count,
-            "error_count": error_count,
+            "enriched_or_simulated": success,
+            "write_errors": int(md.get("write_errors_count", 0)),
             "success_rate": round(rate, 3),
         },
         description=f"Enrichment success rate: {rate:.1%} ({success}/{matched_count})",
     )
 
 
-@asset_check(asset="pdv_data")
-def coord_transform_check(context, pdv_data):
+def eval_coord_transform(md):
     """WARN on coordinate transform issues.
 
     Fails (WARN) if any of:
-      - coord_failures > 0         (transform raised)
-      - version_counter is empty while writes happened
-      - yaml_sha256 is None         (YAML could not be hashed)
+      - coordinate_transform_failures > 0   (transform raised)
+      - no transform version resolved while writes were attempted
+      - the transforms YAML could not be hashed (provenance incomplete)
     """
-    failures = pdv_data.get("coord_failures", 0)
-    version_counter = pdv_data.get("version_counter", {}) or {}
-    yaml_sha256 = pdv_data.get("yaml_sha256")
-    attempted = pdv_data.get("written_count", 0) + pdv_data.get("simulated_count", 0)
+    failures = int(md.get("coordinate_transform_failures", 0))
+    version_count = int(md.get("transform_version_count", 0))
+    yaml_present = bool(md.get("yaml_sha256_present", False))
+    attempted = int(md.get("items_enriched", 0)) + int(md.get("items_simulated", 0))
 
-    unresolved_versions = attempted > 0 and not version_counter
-    missing_sha = yaml_sha256 is None
+    unresolved_versions = attempted > 0 and version_count == 0
+    missing_sha = not yaml_present
 
     passed = (failures == 0) and (not unresolved_versions) and (not missing_sha)
 
@@ -158,33 +151,106 @@ def coord_transform_check(context, pdv_data):
         problems.append("yaml_sha256 unavailable (provenance incomplete)")
 
     description = (
-        "Transforms OK: " + ", ".join(f"{k}={v}" for k, v in sorted(version_counter.items()))
-        if passed else "; ".join(problems)
+        md.get("transform_versions_used", "transforms OK")
+        if passed
+        else "; ".join(problems)
     )
-
     return AssetCheckResult(
         passed=passed,
         severity=AssetCheckSeverity.WARN,
         metadata={
             "coord_failures": failures,
-            "version_counter": str(sorted(version_counter.items())),
-            "yaml_sha256_present": not missing_sha,
+            "transform_version_count": version_count,
+            "yaml_sha256_present": yaml_present,
         },
         description=description,
     )
 
 
-@asset_check(asset="pdv_processing_manifest")
-def manifest_written(context, pdv_processing_manifest):
+def eval_manifest_written(md):
     """ERROR if the processing manifest was not written to any source item."""
-    written = pdv_processing_manifest.get("manifest_written", False)
+    written = bool(md.get("manifest_written", False))
     return AssetCheckResult(
-        passed=bool(written),
+        passed=written,
         severity=AssetCheckSeverity.ERROR,
-        metadata={"status": pdv_processing_manifest.get("status", "unknown")},
+        metadata={"status": md.get("status", "unknown")},
         description=(
             "Processing manifest written to source log item(s)."
             if written
-            else "Processing manifest write FAILED for one or more source items."
+            else "No source log item to write to (partition resolved zero "
+            "pdv_experiment_log items), or a real write failed."
         ),
     )
+
+
+# --- asset checks: read the partition's materialization metadata, then decide ---
+
+
+@asset_check(asset="pdv_log")
+def igsn_validity_rate(context):
+    md = latest_partition_metadata(
+        context.instance, "pdv_log", str(context.partition_key)
+    )
+    if md is None:
+        return no_materialization_result()
+    return eval_igsn_validity(md)
+
+
+@asset_check(asset="pdv_data")
+def zero_pdv_inventory(context):
+    md = latest_partition_metadata(
+        context.instance, "pdv_data", str(context.partition_key)
+    )
+    if md is None:
+        return no_materialization_result(AssetCheckSeverity.ERROR)
+    return eval_zero_inventory(md)
+
+
+@asset_check(asset="pdv_data")
+def pdv_match_rate(context):
+    md = latest_partition_metadata(
+        context.instance, "pdv_data", str(context.partition_key)
+    )
+    if md is None:
+        return no_materialization_result()
+    return eval_pdv_match_rate(md)
+
+
+@asset_check(asset="pdv_data")
+def igsn_consistency(context):
+    md = latest_partition_metadata(
+        context.instance, "pdv_data", str(context.partition_key)
+    )
+    if md is None:
+        return no_materialization_result(AssetCheckSeverity.ERROR)
+    return eval_igsn_consistency(md)
+
+
+@asset_check(asset="pdv_data")
+def enrichment_success_rate(context):
+    md = latest_partition_metadata(
+        context.instance, "pdv_data", str(context.partition_key)
+    )
+    if md is None:
+        return no_materialization_result()
+    return eval_enrichment_success_rate(md)
+
+
+@asset_check(asset="pdv_data")
+def coord_transform_check(context):
+    md = latest_partition_metadata(
+        context.instance, "pdv_data", str(context.partition_key)
+    )
+    if md is None:
+        return no_materialization_result()
+    return eval_coord_transform(md)
+
+
+@asset_check(asset="pdv_processing_manifest")
+def manifest_written(context):
+    md = latest_partition_metadata(
+        context.instance, "pdv_processing_manifest", str(context.partition_key)
+    )
+    if md is None:
+        return no_materialization_result(AssetCheckSeverity.ERROR)
+    return eval_manifest_written(md)

--- a/aimdl_coord_enrichment/partitions.py
+++ b/aimdl_coord_enrichment/partitions.py
@@ -1,0 +1,16 @@
+"""Partition definitions for the HELIX spreadsheet flow.
+
+Single-dimension dynamic partitions keyed on the AIMD-L logical key
+``"<igsn>//<experiment_date>"`` served by
+``GET /aimdl/partition?dataType=pdv_experiment_log``. Partition keys are
+plain strings, so assets read ``context.partition_key`` directly and the
+discovery sensor calls ``build_add_request(sorted(index))``.
+"""
+
+from dagster import DynamicPartitionsDefinition
+
+HELIX_EXPERIMENT_LOG_DATA_TYPE = "pdv_experiment_log"
+
+HELIX_EXPERIMENT_LOG_PARTITIONS = DynamicPartitionsDefinition(
+    name="helix_experiment_log"
+)

--- a/aimdl_coord_enrichment/sensors.py
+++ b/aimdl_coord_enrichment/sensors.py
@@ -1,5 +1,3 @@
-import json
-
 from dagster import (
     DefaultSensorStatus,
     MultiPartitionKey,
@@ -10,11 +8,11 @@ from dagster import (
 )
 
 from aimdl_coord_enrichment.assets import process_helix_assets_job
-from aimdl_coord_enrichment.constants import HELIX_FOLDER_ID
 from aimdl_coord_enrichment.coord_enrichment.inventory import MAXIMA_RUN_PARTITIONS
-from aimdl_coord_enrichment.girder_io import (
-    fetch_partition_index,
-    list_recent_spreadsheets,
+from aimdl_coord_enrichment.girder_io import fetch_partition_index
+from aimdl_coord_enrichment.partitions import (
+    HELIX_EXPERIMENT_LOG_DATA_TYPE,
+    HELIX_EXPERIMENT_LOG_PARTITIONS,
 )
 from aimdl_coord_enrichment.resources import GirderConnection
 
@@ -113,50 +111,38 @@ def maxima_raw_discovery_sensor(
     minimum_interval_seconds=3600,
     default_status=DefaultSensorStatus.STOPPED,
 )
-def helix_folder_sensor(context: SensorEvaluationContext, girder: GirderConnection):
-    """Poll for new experiment log spreadsheets in the HELIX folder.
+def helix_experiment_log_discovery_sensor(
+    context: SensorEvaluationContext,
+    girder: GirderConnection,
+) -> SensorResult:
+    """Discover AIMD-L partitions for HELIX experiment logs.
 
-    Uses a sorted recent-items query instead of recursive folder crawling.
-    Tracks seen item IDs in the cursor to avoid reprocessing.
+    Per tick, fetches the partition index for ``pdv_experiment_log``
+    (keyed ``"<igsn>//<experiment_date>"`` with content-hash values),
+    registers every key on the ``helix_experiment_log`` dynamic
+    dimension, and emits one partitioned RunRequest per key. The run_key
+    embeds the content hash, so unchanged partitions are suppressed and a
+    changed log re-triggers.
     """
-    cursor_data = json.loads(context.cursor or '{"seen": []}')
-    seen = set(cursor_data["seen"])
+    index = fetch_partition_index(girder, HELIX_EXPERIMENT_LOG_DATA_TYPE)
 
-    items = list_recent_spreadsheets(girder, HELIX_FOLDER_ID, limit=100)
+    context.log.info(
+        "helix_experiment_log_discovery_sensor: %d partitions", len(index)
+    )
 
-    new_seen = set(seen)
-    requests = []
-    for item in items:
-        item_id = item["_id"]
-        if item_id not in seen:
-            # Optionally check processing manifest
-            existing_meta = item.get("meta", {})
-            processing_status = existing_meta.get("processing_status", {})
-            if processing_status.get("status") == "completed_clean":
-                context.log.info(
-                    "Skipping %s — already processed cleanly on %s",
-                    item["name"],
-                    processing_status.get("last_processed", "unknown"),
-                )
-                new_seen.add(item_id)
-                continue
-
-            requests.append(
-                RunRequest(
-                    run_key=item_id,
-                    run_config={
-                        "ops": {
-                            "experiment_log_source": {
-                                "config": {
-                                    "item_id": item_id,
-                                    "filename": item["name"],
-                                }
-                            }
-                        }
-                    },
-                )
+    return SensorResult(
+        dynamic_partitions_requests=[
+            HELIX_EXPERIMENT_LOG_PARTITIONS.build_add_request(sorted(index))
+        ],
+        run_requests=[
+            RunRequest(
+                run_key=f"helix-pdv-log|{key}|hash={content_hash}",
+                partition_key=key,
+                tags={
+                    "data_type": HELIX_EXPERIMENT_LOG_DATA_TYPE,
+                    "content_hash": content_hash,
+                },
             )
-            new_seen.add(item_id)
-
-    context.update_cursor(json.dumps({"seen": list(new_seen)}))
-    return requests
+            for key, content_hash in index.items()
+        ],
+    )

--- a/aimdl_coord_enrichment/spreadsheet.py
+++ b/aimdl_coord_enrichment/spreadsheet.py
@@ -1,0 +1,279 @@
+"""Pure helper functions for the HELIX spreadsheet flow.
+
+Context-free, unit-testable computation extracted from the former
+nine-asset spreadsheet DAG. Each function reuses an existing domain
+helper (``validate_igsn``, ``match_pdv_file``, ``transform_station_to_sample``,
+``build_coord_provenance``) rather than reimplementing it. No ``dagster``
+import lives here — the three partitioned assets in ``assets.py`` call
+these and own all durable external-state transitions.
+"""
+
+import json
+import math
+from datetime import datetime, timezone
+
+import pandas as pd
+
+from aimdl_coord_enrichment import __version__ as PIPELINE_VERSION
+from aimdl_coord_enrichment.constants import COLUMN_MAP
+from aimdl_coord_enrichment.coordinates import transform_station_to_sample
+from aimdl_coord_enrichment.girder_io import nan_to_none
+from aimdl_coord_enrichment.matching import match_pdv_file
+from aimdl_coord_enrichment.provenance import build_coord_provenance
+from aimdl_coord_enrichment.validation import NpEncoder, validate_igsn
+
+
+def normalize_experiment_log(df):
+    """Apply COLUMN_MAP rename to a raw experiment-log DataFrame."""
+    return df.rename(columns=COLUMN_MAP)
+
+
+def validate_log_rows(df):
+    """Validate IGSNs for each row.
+
+    Returns ``(df_with_valid_igsn, igsn_issues)`` where the returned
+    DataFrame has a ``valid_igsn`` column added and ``igsn_issues`` is a
+    list of structured issue dicts (each carrying its ``row`` index).
+    """
+    df = df.copy()
+    igsn_issues = []
+    valid_igsns = []
+
+    for idx, row in df.iterrows():
+        valid_igsn, issue = validate_igsn(row.get("Sample_IGSN"))
+        valid_igsns.append(valid_igsn)
+        if issue is not None:
+            issue["row"] = idx
+            igsn_issues.append(issue)
+
+    df["valid_igsn"] = valid_igsns
+    return df, igsn_issues
+
+
+def match_pdv_rows(df, pdv_items):
+    """Match each row's PDV_FileName to the inventory and cross-check IGSNs.
+
+    Returns ``(matches, pdv_issues)`` where ``matches`` is
+    ``{row_idx: pdv_item}`` and ``pdv_issues`` carries not_found /
+    ambiguous / igsn_mismatch issues (each with its ``row`` index).
+    """
+    matches = {}
+    pdv_issues = []
+
+    for idx, row in df.iterrows():
+        pdv_filename = row.get("PDV_FileName")
+        pdv_item, issue = match_pdv_file(pdv_items, pdv_filename)
+        if pdv_item is not None:
+            matches[idx] = pdv_item
+            row_igsn = row.get("valid_igsn")
+            item_igsn = pdv_item.get("meta", {}).get("igsn")
+            if row_igsn and item_igsn and row_igsn != item_igsn:
+                pdv_issues.append({
+                    "pdv_filename": pdv_filename,
+                    "type": "igsn_mismatch",
+                    "row": idx,
+                    "spreadsheet_igsn": row_igsn,
+                    "item_igsn": item_igsn,
+                })
+        if issue is not None:
+            issue["row"] = idx
+            pdv_issues.append(issue)
+
+    return matches, pdv_issues
+
+
+def count_rows_with_pdv(df):
+    """Count rows whose PDV_FileName is non-null, non-NaN, non-empty."""
+    return sum(
+        1
+        for _, row in df.iterrows()
+        if row.get("PDV_FileName") is not None
+        and not (
+            isinstance(row.get("PDV_FileName"), float)
+            and math.isnan(row.get("PDV_FileName"))
+        )
+        and str(row.get("PDV_FileName")).strip() != ""
+    )
+
+
+def _parse_row_timestamp(raw):
+    """Return (tz-aware datetime or None, was_naive: bool, origin: str)."""
+    if raw is None:
+        return None, False, "missing"
+    try:
+        ts = pd.to_datetime(raw)
+    except (ValueError, TypeError):
+        return None, False, "unparseable"
+    if pd.isna(ts):
+        return None, False, "missing"
+    py_ts = ts.to_pydatetime()
+    if py_ts.tzinfo is None:
+        py_ts = py_ts.replace(tzinfo=timezone.utc)
+        return py_ts, True, "spreadsheet_timestamp_col_assumed_utc"
+    return py_ts, False, "spreadsheet_timestamp_col"
+
+
+def write_pdv_metadata(
+    girder,
+    df,
+    matches,
+    *,
+    run_id,
+    source_item_id,
+    yaml_sha256,
+    transformer_version,
+):
+    """Write coordinate + provenance metadata to each matched PDV item.
+
+    For each matched row: parse the shot timestamp, transform station to
+    sample coordinates (version selected by timestamp), build the
+    coord_provenance block, and write to the Girder item. Each row's
+    provenance is attributed to its originating source-log item via the
+    ``_source_item_id`` column when present, else ``source_item_id``.
+
+    Returns a summary dict with ``written_count``, ``write_errors``,
+    ``coord_failures``, ``version_counter``, ``naive_timestamps_count``.
+    """
+    naive_timestamps_count = 0
+    version_counter = {}
+    written_count = 0
+    write_errors = []
+    coord_failures = 0
+
+    for row_idx, pdv_item in matches.items():
+        row = df.loc[row_idx]
+
+        station_x = nan_to_none(row.get("Flyer_X_Position_Final_mm"))
+        station_y = nan_to_none(row.get("Flyer_Y_Position_Final_mm"))
+        shot_ts, was_naive, ts_origin = _parse_row_timestamp(row.get("Timestamp"))
+        if was_naive:
+            naive_timestamps_count += 1
+        sample_x, sample_y, transform_name = transform_station_to_sample(
+            station_x, station_y, timestamp=shot_ts
+        )
+        if transform_name is not None:
+            version_counter[transform_name] = version_counter.get(transform_name, 0) + 1
+        # ensure that sample_x,y have only 4 meaningful digits to avoid bogus precision
+        if sample_x is not None:
+            sample_x = round(sample_x, 4)
+        if sample_y is not None:
+            sample_y = round(sample_y, 4)
+
+        if station_x is not None and station_y is not None and sample_x is None:
+            coord_failures += 1
+
+        row_source_item_id = row.get("_source_item_id")
+        if row_source_item_id is None or (
+            isinstance(row_source_item_id, float) and math.isnan(row_source_item_id)
+        ):
+            row_source_item_id = source_item_id
+
+        coord_prov = build_coord_provenance(
+            instrument="HELIX",
+            transform_version=transform_name,
+            transform_yaml_sha256=yaml_sha256 or "",
+            transformer_version=transformer_version,
+            pipeline_version=PIPELINE_VERSION,
+            source_timestamp=shot_ts,
+            source_timestamp_origin=ts_origin,
+            station_coord_source={
+                "kind": "helix_experiment_log",
+                "spreadsheet_item_id": row_source_item_id,
+                "spreadsheet_row_index": int(row_idx),
+                "spreadsheet_pdv_filename": row.get("PDV_FileName"),
+            },
+            dagster_run_id=run_id,
+        )
+
+        metadata = {
+            "Flyer_Row": nan_to_none(row.get("Flyer_Row")),
+            "Flyer_Column": nan_to_none(row.get("Flyer_Column")),
+            "Station_X": station_x,
+            "Station_Y": station_y,
+            "Sample_X": sample_x,
+            "Sample_Y": sample_y,
+            "coord_provenance": coord_prov,
+        }
+        # Ensure all values are JSON-serializable
+        metadata = json.loads(json.dumps(metadata, cls=NpEncoder))
+
+        try:
+            girder.addMetadataToItem(pdv_item["_id"], metadata)
+            written_count += 1
+        except Exception as exc:
+            write_errors.append({"row": row_idx, "error": str(exc)})
+
+    return {
+        "written_count": written_count,
+        "write_errors": write_errors,
+        "coord_failures": coord_failures,
+        "version_counter": version_counter,
+        "naive_timestamps_count": naive_timestamps_count,
+    }
+
+
+def summarize_pdv_processing(pdv_log, pdv_data):
+    """Aggregate issues into a processing summary (status + issues_summary).
+
+    Replaces the old quality_report + processing_manifest aggregation,
+    minus ALPSS completeness (coverage now lives in the read-only
+    helix_pdv_coverage_observer).
+    """
+    df = pdv_log["dataframe"]
+    igsn_issues = pdv_log["igsn_issues"]
+    pdv_issues = pdv_data["pdv_issues"]
+    write_errors = pdv_data["write_errors"]
+
+    total_rows = len(df)
+    valid_igsn_count = (
+        int(df["valid_igsn"].notna().sum()) if "valid_igsn" in df.columns else 0
+    )
+
+    issues_summary = {
+        "igsn_invalid": sum(1 for i in igsn_issues if i.get("issue") == "invalid_format"),
+        "igsn_missing": sum(1 for i in igsn_issues if i.get("issue") == "missing"),
+        "pdv_not_found": sum(1 for i in pdv_issues if i.get("type") == "not_found"),
+        "pdv_ambiguous": sum(1 for i in pdv_issues if i.get("type") == "ambiguous"),
+        "igsn_mismatch": sum(1 for i in pdv_issues if i.get("type") == "igsn_mismatch"),
+        "write_errors": len(write_errors),
+        "coord_failures": pdv_data.get("coord_failures", 0),
+    }
+
+    has_issues = any(v > 0 for v in issues_summary.values())
+    status = "completed_with_warnings" if has_issues else "completed_clean"
+
+    return {
+        "status": status,
+        "has_issues": has_issues,
+        "issues_summary": issues_summary,
+        "total_rows": total_rows,
+        "rows_valid_igsn": valid_igsn_count,
+        "rows_matched_pdv": pdv_data["matched_count"],
+        "rows_enriched": pdv_data["written_count"],
+    }
+
+
+def write_processing_manifest(girder, item_id, summary, *, run_id):
+    """Write meta.processing_status to one source-log Girder item.
+
+    Returns the manifest dict, with ``write_failed`` set True if the
+    Girder write raised.
+    """
+    manifest = {
+        "last_processed": datetime.now(timezone.utc).isoformat(),
+        "dagster_run_id": run_id,
+        "pipeline_version": PIPELINE_VERSION,
+        "total_rows": summary["total_rows"],
+        "rows_valid_igsn": summary["rows_valid_igsn"],
+        "rows_matched_pdv": summary["rows_matched_pdv"],
+        "rows_enriched": summary["rows_enriched"],
+        "status": summary["status"],
+        "issues_summary": summary["issues_summary"],
+    }
+
+    try:
+        girder.addMetadataToItem(item_id, {"processing_status": manifest})
+    except Exception:
+        manifest["write_failed"] = True
+
+    return manifest

--- a/aimdl_coord_enrichment/spreadsheet.py
+++ b/aimdl_coord_enrichment/spreadsheet.py
@@ -122,6 +122,7 @@ def write_pdv_metadata(
     source_item_id,
     yaml_sha256,
     transformer_version,
+    dry_run=False,
 ):
     """Write coordinate + provenance metadata to each matched PDV item.
 
@@ -131,12 +132,18 @@ def write_pdv_metadata(
     provenance is attributed to its originating source-log item via the
     ``_source_item_id`` column when present, else ``source_item_id``.
 
-    Returns a summary dict with ``written_count``, ``write_errors``,
-    ``coord_failures``, ``version_counter``, ``naive_timestamps_count``.
+    When ``dry_run`` is True the coordinate metadata is fully computed but
+    the Girder PUT is skipped; the would-be write is tallied in
+    ``simulated_count`` instead of ``written_count``.
+
+    Returns a summary dict with ``written_count``, ``simulated_count``,
+    ``write_errors``, ``coord_failures``, ``version_counter``,
+    ``naive_timestamps_count``.
     """
     naive_timestamps_count = 0
     version_counter = {}
     written_count = 0
+    simulated_count = 0
     write_errors = []
     coord_failures = 0
 
@@ -197,6 +204,10 @@ def write_pdv_metadata(
         # Ensure all values are JSON-serializable
         metadata = json.loads(json.dumps(metadata, cls=NpEncoder))
 
+        if dry_run:
+            simulated_count += 1
+            continue
+
         try:
             girder.addMetadataToItem(pdv_item["_id"], metadata)
             written_count += 1
@@ -205,6 +216,7 @@ def write_pdv_metadata(
 
     return {
         "written_count": written_count,
+        "simulated_count": simulated_count,
         "write_errors": write_errors,
         "coord_failures": coord_failures,
         "version_counter": version_counter,
@@ -253,10 +265,14 @@ def summarize_pdv_processing(pdv_log, pdv_data):
     }
 
 
-def write_processing_manifest(girder, item_id, summary, *, run_id):
+def write_processing_manifest(girder, item_id, summary, *, run_id, dry_run=False):
     """Write meta.processing_status to one source-log Girder item.
 
-    Returns the manifest dict, with ``write_failed`` set True if the
+    When ``dry_run`` is True the manifest is built but the Girder PUT is
+    skipped (and ``write_failed`` is never set — the would-be write is
+    treated as a success for reporting).
+
+    Returns the manifest dict, with ``write_failed`` set True if a real
     Girder write raised.
     """
     manifest = {
@@ -270,6 +286,9 @@ def write_processing_manifest(girder, item_id, summary, *, run_id):
         "status": summary["status"],
         "issues_summary": summary["issues_summary"],
     }
+
+    if dry_run:
+        return manifest
 
     try:
         girder.addMetadataToItem(item_id, {"processing_status": manifest})

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1,0 +1,491 @@
+# Specification — Coordinate Enrichment for AIMD‑L (`aimdl_coord_enrichment`)
+
+> **Status:** Reverse-engineered from source + test suite at version `0.6.0`.
+> **Method:** This is a *descriptive* spec — every requirement is extracted from
+> code behavior that the existing tests pin. It is written so it can also serve
+> as a *prescriptive* spec going forward: each requirement has a stable ID, and
+> the test that currently guarantees it is cited so the spec ↔ test ↔ code
+> traceability is explicit.
+>
+> **Why it exists:** to separate the *problem* (what coordinates must end up on
+> which Girder items, and why) from the *current solution* (8 jobs, dynamic
+> partitions, two DAGs). Use §9 (Scope Tiers) to reason about how much of the
+> current machinery the problem actually requires.
+
+--
+
+## 1. Problem statement
+
+Scientific data files for two instruments (HELIX, MAXIMA) live as items in a
+Girder repository (AIMD‑L collection). Downstream analysis needs every relevant
+item to carry **sample-frame coordinates** (`Sample_X`, `Sample_Y`) plus the
+**station-frame coordinates** they were derived from (`Station_X`, `Station_Y`)
+and a **provenance record** (`coord_provenance`) describing exactly how those
+numbers were produced.
+
+The coordinates are not present on the items at creation time. They must be
+**computed and written back** by reading from one of three sources, depending on
+the item's role, and applying a versioned `Station → Sample` transform.
+
+The system shall write the same four coordinate fields + provenance to every
+in-scope item, regardless of which source the coordinates came from.
+
+--
+
+## 2. Ubiquitous language (glossary)
+
+| Term | Meaning |
+|---|---|
+| **Item** | A Girder item (a file + `meta` dict). Identified by `_id`. |
+| **`data_type`** | `meta.data_type` on an item. The primary routing key (`pdv_trace`, `xrd_raw`, …). |
+| **IGSN** | Sample identifier. Pattern `[A-Za-z]{6}\d{5}(?:-[A-Za-z0-9]+)?`. |
+| **Station coordinates** | Instrument-frame position in mm (`Station_X/Y`). The raw input. |
+| **Sample coordinates** | Sample-frame position in mm (`Sample_X/Y`). The deliverable. |
+| **Station → Sample transform** | A versioned coordinate transform, selected by shot timestamp. Provided by the external `coordinate-transformer` package. |
+| **Leaf item** | An item whose station coordinates come from a *primary source* (spreadsheet row or `instructions.txt`). |
+| **Derived item** | An item that has no primary source; it **inherits** station coordinates from a parent item via `meta.prov.wasDerivedFrom`. |
+| **`coord_provenance`** | A dict written next to the coordinates recording transform version, config hash, source, timestamp, and run id. |
+| **Enrichment** | The act of computing coordinates + provenance and writing them to an item. |
+| **Reconciliation** | A periodic sweep that re-enriches only items whose inputs changed. |
+| **AIMD‑L run key** | `"<igsn>//<experiment_date>"` — the natural partition key for MAXIMA. |
+
+--
+
+## 3. System context
+
+### 3.1 Actors
+- **`coordinate-transformer` package** — external, versioned `Station→Sample` math, selected by timestamp.
+- **Girder API** (`data.htmdec.org/api/v1`) — item store + custom `/aimdl/*` indexed endpoints.
+- **Operator** — a human who opts pipelines into running via the Dagster UI (everything ships stopped).
+- **Upstream producers** — the HELIX experiment-log spreadsheet author; the `amdee_xrd` Girder plugin that writes `prov.wasDerivedFrom` on MAXIMA derived items.
+
+### 3.2 In-scope item types and the coordinate source for each
+
+| Instrument | `data_type` | Role | Coordinate source | Approx. count |
+|---|---|---|---|---|
+| HELIX | `pdv_trace` | leaf* | spreadsheet row (`Flyer_X/Y_Position_Corrected`) | 2,559 |
+| HELIX | `pdv_alpss_output` | derived | inherit from parent `pdv_trace` | 16,707 |
+| HELIX | `pdv_alpss_result` | derived | inherit from parent `pdv_trace` | 549 |
+| HELIX | `pdv_alpss_results` | derived | inherit from parent `pdv_trace` | 1,526 |
+| MAXIMA | `xrd_raw` | leaf | `instructions.txt` scan-point | 18,429 |
+| MAXIMA | `xrf_raw` | leaf | `instructions.txt` scan-point | 8,105 |
+| MAXIMA | `xrd_derived` | derived | inherit from parent `xrd_raw` master.h5 | 28,219 |
+
+\* `pdv_trace` is enriched by the **spreadsheet DAG**, and is treated as an
+*external / pre-enriched* parent by the coord_enrichment DAG's instrument
+registry (HELIX leaf set is intentionally empty there).
+
+**Explicitly out of scope:** `xrd_metadata`, `pdv_experiment_log`,
+`xrd_calibrant_raw`, `xrd_calibrant_derived`, `unclassified`.
+
+--
+
+## 4. Domain invariants (apply everywhere)
+
+These are the cross-cutting rules. Every capability in §5 inherits them.
+
+- **INV‑1 — Uniform output.** Every successful enrichment writes exactly
+  `Station_X`, `Station_Y`, `Sample_X`, `Sample_Y`, `coord_provenance` to the
+  item. Derived items write the *parent's* station coordinates verbatim.
+- **INV‑2 — Timezone-aware time, always.** Any datetime that selects a transform
+  version or is recorded in provenance MUST be tz-aware. Naive datetimes raise
+  (`ValueError` in the transform/provenance layer; `ResolutionError` in the
+  MAXIMA layer). *Tests: `test_naive_timestamp_raises`,
+  `test_build_coord_provenance_naive_timestamp_raises`,
+  `_experiment_date` naive branch.*
+- **INV‑3 — Version selection is timestamp-driven.** `Sample = transform(Station)`
+  where the transform version is the one valid at the shot timestamp.
+  `valid_from` is **inclusive**, `valid_until` is **exclusive**.
+  *Tests: `test_helix_boundary_just_before_is_v1`, `test_helix_boundary_at_cutover_is_v2`.*
+- **INV‑4 — Derived items reuse the parent's exact version.** A derived item does
+  not re-resolve the version by its own timestamp; it re-applies the parent's
+  recorded `transform_version` label. *Tests: `enriched_helix_alpss` "inherits v2
+  when parent is v2".*
+- **INV‑5 — Ambiguity is never silently resolved.** Multiple PDV-trace filename
+  matches, multiple `instructions.txt`, or a non-unique `raw/` subfolder yield an
+  error/`None`, never an arbitrary pick. *Tests:
+  `test_find_parent_pdv_item_id_none_on_ambiguous`,
+  `test_fetch_instructions_multiple_raises`,
+  `test_find_master_h5_item_id_missing_raw_subfolder`.*
+- **INV‑6 — Idempotent writes.** A re-run writes an item only if a *meaningful*
+  provenance field changed (see SPEC‑PROV‑02). Identity/audit fields never
+  trigger a rewrite.
+- **INV‑7 — Failure is per-item, not per-run.** A resolution or write failure on
+  one item is recorded (counted + listed) and the run continues. *Tests: the
+  `resolution_errors` / `write_errors` branches in every leaf test file.*
+- **INV‑8 — Safe by default.** Every mutating pipeline supports `dry_run`
+  (default `True`), and every sensor/schedule ships **STOPPED**. Nothing writes
+  to Girder on deploy without an operator opting in. *Tests:
+  `test_all_schedules_default_stopped`, dry-run config tests.*
+
+--
+
+## 5. Capability specifications
+
+Each capability lists requirements (`SPEC‑*`) in EARS / Given‑When‑Then form.
+
+### C1 — HELIX spreadsheet → `pdv_trace` enrichment
+*(the "helix_spreadsheet" DAG; 9 assets today)*
+
+- **SPEC‑HELIX‑01 — Ingest.** When given a spreadsheet item id + filename, the
+  system shall download the first file of that item and load it (`.csv` →
+  `read_csv`, else `read_excel`), then rename columns via `COLUMN_MAP`.
+  *(`raw_experiment_log`; `download_and_read` raises if the item has no files.)*
+- **SPEC‑HELIX‑02 — IGSN validation.** For each row, the system shall validate
+  `Sample_IGSN` against the IGSN pattern, classifying each as `valid`,
+  `missing` (None/NaN/empty), or `invalid_format`. *Tests: `test_validated_rows_pure`.*
+- **SPEC‑HELIX‑03 — PDV inventory.** The system shall fetch all `pdv_trace`
+  items via the indexed `/aimdl/datafiles` endpoint (paginated 100/page), not by
+  crawling folders. *Tests: `test_fetch_all_paginates`,
+  `test_fetch_datafiles_respects_limit_cap`.*
+- **SPEC‑HELIX‑04 — Matching.** For each row with a non-empty `PDV_FileName`, the
+  system shall match it to inventory items by **filename prefix**
+  (`item.name.startswith(filename)`). Given 0 matches → `not_found`; given >1 →
+  `ambiguous` (no item chosen); given exactly 1 → matched. Blank/NaN filenames
+  are skipped silently with no issue. *Tests: `test_exact_match`,
+  `test_no_match`, `test_ambiguous_match`, `test_nan_filename`.*
+- **SPEC‑HELIX‑05 — IGSN consistency.** When a row matches an item and both carry
+  a truthy IGSN that differ, the system shall record an `igsn_mismatch` issue
+  (but still keep the match). *Tests: `test_igsn_mismatch_detection`.*
+- **SPEC‑HELIX‑06 — Enrich.** For each matched item, the system shall compute
+  `Station_X/Y` from `Flyer_X/Y_Position_Corrected`, derive `Sample_X/Y` via the
+  timestamp-selected transform (rounded to 4 dp), build `coord_provenance`
+  (`station_coord_source.kind = "helix_experiment_log"`), and write the
+  coordinate payload to the matched item. *Tests:
+  `test_enriched_pdv_metadata_writes_provenance`,
+  `test_enriched_pdv_metadata_version_boundary_dispatch`.*
+- **SPEC‑HELIX‑07 — Timestamp normalization.** The shot timestamp comes from the
+  row `Timestamp` column; a naive value is assumed UTC (origin recorded as
+  `..._assumed_utc`) and counted; unparseable/missing → no version selection.
+- **SPEC‑HELIX‑08 — Audit manifest + idempotent skip.** After processing, the
+  system shall write a `processing_status` manifest to the *source spreadsheet*
+  item (counts + `status ∈ {completed_clean, completed_with_warnings}`), and the
+  sensor shall skip spreadsheets already marked `completed_clean`. *Tests:
+  `test_processing_manifest_clean`, `test_processing_manifest_with_warnings`.*
+- **SPEC‑HELIX‑09 — Completeness reporting.** The system shall report, per
+  matched IGSN, whether an ALPSS result exists (coverage %). *(`quality_report`,
+  `alpss_results_inventory`; `test_quality_report_alpss_completeness`.)*
+
+### C2 — Station → Sample transform (shared)
+
+- **SPEC‑XFORM‑01.** Given `(station_x, station_y, timestamp)`, the system shall
+  return `(sample_x, sample_y, transform_name)` using the transform version valid
+  at `timestamp`; given `timestamp=None`, the currently-valid version.
+- **SPEC‑XFORM‑02 — Graceful degradation.** Given missing inputs, no configured
+  transformer, or any transform exception, the system shall return
+  `(None, None, None)` (logged), never crash. *Tests: `test_none_input`,
+  `test_missing_transformer`.*
+- **SPEC‑XFORM‑03 — HELIX calibration boundary.** HELIX v1 (before
+  2026‑04‑01T00:00‑04:00) is a flip about x=20 (`x' = 40 − x`); v2 (on/after) is
+  the **identity** transform — the station frame was physically realigned to the
+  sample frame. *Tests: `test_helix_v1_flip_before_cutover`,
+  `test_helix_v2_identity_after_cutover`.*
+- **SPEC‑XFORM‑04 — Named-version reuse.** The system shall support transforming
+  with an explicitly named version label (bypassing date resolution) for derived
+  inheritance. *Tests: `test_transform_with_named_version_happy_path_v1/v2`.*
+  *(Implementation note: currently reaches into the transformer's private
+  `_transforms`; an upstream public API is a known TODO.)*
+
+### C3 — Provenance & idempotency (shared)
+
+- **SPEC‑PROV‑01 — Provenance shape.** Every enriched item's `coord_provenance`
+  shall contain: `instrument`, `transform_version`, `transform_yaml_sha256`,
+  `transformer_version`, `pipeline_version`, `source_timestamp` (ISO or null),
+  `source_timestamp_origin`, `station_coord_source`, `enriched_at`; plus
+  `dagster_run_id` **only when known**. *Tests: `test_build_coord_provenance_*`.*
+- **SPEC‑PROV‑02 — Write decision.** The system shall (re)write an item iff there
+  is no stored provenance (`first_write`) OR one of these changed:
+  `transform_yaml_sha256`, `transformer_version`, `transform_version`,
+  `station_coord_source`. It shall NOT rewrite for changes to `enriched_at`,
+  `source_timestamp`, `dagster_run_id`, or `pipeline_version`. *Tests:
+  `test_coord_enrichment_overwrite.py` (all branches).*
+- **SPEC‑PROV‑03 — Config snapshot.** The system shall capture a frozen snapshot
+  of the transform config (YAML sha256, transformer version, versions per
+  instrument) so provenance references a reproducible config. *Tests:
+  `test_coord_enrichment_config_snapshot.py`.*
+- **SPEC‑PROV‑04 — `station_coord_source` discriminator.** Its `kind` shall be
+  one of: `helix_experiment_log` (C1), `maxima_instructions` (C5),
+  `inherited` (C4/C6).
+
+### C4 — HELIX ALPSS derived enrichment (inheritance)
+
+- **SPEC‑ALPSS‑01 — Provenance tagging.** Before enrichment, the system shall set
+  `meta.prov.wasDerivedFrom` on each ALPSS item to its parent `pdv_trace`,
+  resolved by filename stem (`<stem>.csv`). Unresolvable items are recorded; an
+  ERROR check fires if any HELIX item is left unresolved. *Tests:
+  `test_coord_enrichment_provenance_tagging.py`, `all_helix_alpss_tagged`.*
+- **SPEC‑ALPSS‑02 — Inherit.** For each ALPSS item with a resolvable parent, the
+  system shall read the parent's `Station_X/Y` + recorded `transform_version`,
+  re-apply that version to produce `Sample_X/Y`, and write the payload with
+  `station_coord_source.kind = "inherited"`. *Tests:
+  `test_coord_enrichment_helix_alpss.py`.*
+- **SPEC‑ALPSS‑03 — Parent readiness.** Given a parent not yet enriched (missing
+  `Station_X/Y` or `coord_provenance`), the item shall be recorded as a
+  resolution error, not written.
+
+### C5 — MAXIMA raw enrichment (`xrd_raw`, `xrf_raw`)
+
+- **SPEC‑MAXR‑01 — Self-fetching partition.** Each partition `(data_type, run)`
+  shall fetch its own items and its own `instructions.txt` via
+  `/aimdl/partition/details` keyed on the AIMD‑L run key. It depends on no
+  inventory or provenance asset. *Tests: `test_coord_enrichment_maxima_raw.py`.*
+- **SPEC‑MAXR‑02 — Scan-point lookup.** Station coordinates come from
+  `instructions.txt` (`sample.scan_points[i]` = `[x, y]`), where `i` is parsed
+  from the filename (`scan_point_<i>...`). Timestamp comes from
+  `meta.experiment_date`. *Tests: `test_parse_scan_point_index_*`,
+  `test_scan_point_coords_*`.*
+- **SPEC‑MAXR‑03 — Missing/duplicate instructions.** Given no `instructions.txt`,
+  every item in the partition is recorded as a resolution error
+  (stage `instructions`). Given multiple, the first is used and the rest are
+  recorded as duplicate warnings. *Tests: missing/duplicate instructions tests.*
+- **SPEC‑MAXR‑04 — `instructions.txt` validation.** The payload must be JSON with
+  `sample.scan_points` a non-empty list of numeric `[x, y]` pairs; any violation
+  is a `ResolutionError`. *Tests: `test_parse_instructions_json_*`.*
+
+### C6 — MAXIMA derived enrichment (`xrd_derived`)
+
+- **SPEC‑MAXD‑01 — Inherit from master.h5.** Each `xrd_derived` item shall
+  inherit `Station_X/Y` + version from its parent (`scan_point_<i>_master.h5`),
+  linked via `prov.wasDerivedFrom` written upstream by `amdee_xrd`. *Tests:
+  `test_coord_enrichment_maxima_derived.py`.*
+- **SPEC‑MAXD‑02 — Parent-readiness gate.** Given the partition has items but
+  **zero** parent `xrd_raw` items are enriched, the asset shall fail fast with a
+  message naming `enriched_maxima_raw` and the `0/<total>` ratio; given partial
+  enrichment, it shall warn and continue. *Tests:
+  `test_fast_fails_when_no_parents_enriched`, partial-warn test.*
+- **SPEC‑MAXD‑03 — Provenance validity check.** An ERROR-severity check shall
+  verify the `amdee_xrd` prov links are present and resolvable (counts
+  `inherit_from_parent`-stage errors). *Tests: `maxima_xrd_derived_provenance_valid`.*
+- **SPEC‑MAXD‑04 — Raw scope filter.** Only `xrd_derived` items physically under a
+  `raw/` subfolder are in scope. *Tests: `filter_to_raw_subfolder` tests.*
+
+### C7 — Inventory & discovery
+
+- **SPEC‑INV‑01 — In-scope inventory.** The system shall produce an inventory of
+  all in-scope items keyed `"<INSTRUMENT>/<data_type>"`, keeping only items with
+  a truthy `meta.igsn` and an in-scope `data_type`. Every in-scope key appears
+  even when empty. *Tests: `test_inventory_returns_all_in_scope_data_type_keys`.*
+- **SPEC‑INV‑02 — Meta-preserving fetch.** MAXIMA partition-aware types shall be
+  fetched via `/aimdl/partition*` (preserves `experiment_date`, `prov`), not
+  `/aimdl/datafiles` (which strips meta). *Tests:
+  `test_items_carry_full_meta_through_inventory`.*
+- **SPEC‑DISC‑01 — Event-driven discovery.** A sensor shall poll the partition
+  index for `xrd_raw`/`xrf_raw`/`xrd_metadata`, register new AIMD‑L run keys on
+  the dynamic dimension, and emit one deduped RunRequest per `(data_type, run)`.
+  The dedup key composes both the raw and metadata content hashes; either
+  changing re-triggers. *Tests: `test_sensors_maxima_discovery.py`.*
+- **SPEC‑DISC‑02 — Gap-filling reconciliation.** A weekly schedule shall
+  enumerate registered partitions and emit a (dry-run) RunRequest only for those
+  lacking a successful materialization. *Tests:
+  `test_maxima_raw_reconciliation_*`.*
+
+### C8 — Reporting & manifests
+
+- **SPEC‑RPT‑01 — State report.** The system shall aggregate per-partition leaf
+  counts (`seen/written/simulated/skipped/coord_failures/resolution_errors`),
+  tagging state, and PDV coverage into one report — reading leaf state from the
+  event log so it runs even with zero leaf materializations. *Tests:
+  `test_coord_enrichment_report_fresh.py`.*
+- **SPEC‑RPT‑02 — Manifest.** The system shall write a status manifest to a
+  configurable Girder tracking item (config id → env → unset), skipping the
+  write under dry-run or when no item is configured. *Tests:
+  `test_coord_enrichment_manifest.py`.*
+- **SPEC‑RPT‑03 — PDV coverage.** The system shall report `pdv_trace` items as
+  fully-enriched / partial / unenriched / missing-igsn with a coverage rate.
+  *Tests: `test_coord_enrichment_pdv_observer.py`.*
+
+### C9 — Data-quality checks (advisory, non-blocking)
+
+All checks are `@asset_check`; none gate execution. Partitioned-leaf checks read
+materialization metadata from the event log (see SPEC‑ORCH‑03).
+
+| Check | Asset | Severity | Fires when |
+|---|---|---|---|
+| `zero_inventory` | `pdv_trace_inventory` | ERROR | 0 items |
+| `igsn_validity_rate` | `validated_rows` | WARN | < 80% valid |
+| `pdv_match_rate` | `pdv_cross_references` | WARN | < 50% matched |
+| `igsn_consistency` | `pdv_cross_references` | ERROR | any mismatch |
+| `enrichment_success_rate` (+ per-leaf variants) | enrich assets | WARN | < 90% success |
+| `coord_transform_check` / `no_coord_transform_failures_*` | enrich assets | WARN | any transform failure |
+| `maxima_xrd_derived_provenance_valid` | `enriched_maxima_derived` | ERROR | any prov-link error |
+| `pdv_coverage_above_threshold` | `helix_pdv_coverage_observer` | WARN | < 50% coverage |
+| `inventory_nonempty_per_instrument` | `enrichable_items_inventory` | WARN | any empty key |
+| `all_helix_alpss_tagged` | `helix_alpss_provenance_tagged` | ERROR | any HELIX unresolved |
+
+*Thresholds (0.8, 0.5, 0.9) are inline literals — see Open Question Q5.*
+
+### C10 — Orchestration & safety
+
+- **SPEC‑ORCH‑01 — HELIX sensor.** A folder sensor shall poll the HELIX folder
+  for new spreadsheets (recent-items query, not crawl), dedup via cursor, skip
+  `completed_clean`, and emit one run per new spreadsheet. STOPPED by default,
+  ≥3600 s interval.
+- **SPEC‑ORCH‑02 — Resource.** A `GirderConnection` resource shall manage session
+  + auth and expose the upstream `GirderClient` (`get`, `downloadFile`,
+  `addMetadataToItem`) to assets/sensors.
+- **SPEC‑ORCH‑03 — Partition isolation.** Per-partition asset checks shall NOT
+  take the partitioned asset as an input (which forces an IOManager load across
+  the partition cross-product and fails on unmaterialized siblings); they read
+  the current partition's materialization metadata instead. *Tests:
+  `test_leaf_check_partition_isolation.py`.*
+- **SPEC‑ORCH‑04 — Module annotation rule.** Dagster-adjacent modules shall NOT
+  use `from __future__ import annotations` (breaks `Config` schema resolution).
+  *Tests: `test_annotations_rule.py`.*
+- **SPEC‑ORCH‑05 — Asset grouping.** Every asset shall belong to one of six named
+  groups; none in the implicit `default` group. *Tests: `test_asset_groups.py`.*
+
+--
+
+## 6. The written data contract
+
+Payload written to an enriched item (`addMetadataToItem`):
+
+```json
+{
+  "Station_X": 19.725,
+  "Station_Y": 20.631,
+  "Sample_X": 12.3456,
+  "Sample_Y": 7.8901,
+  "coord_provenance": {
+    "instrument": "HELIX",
+    "transform_version": "HELIX/v2",
+    "transform_yaml_sha256": "<hex|''>",
+    "transformer_version": "1.2.3",
+    "pipeline_version": "0.6.0",
+    "source_timestamp": "2026-04-16T17:12:19+00:00",
+    "source_timestamp_origin": "spreadsheet_timestamp_col",
+    "station_coord_source": { "kind": "...", "...": "..." },
+    "enriched_at": "2026-06-15T03:00:00+00:00",
+    "dagster_run_id": "abc123"
+  }
+}
+```
+
+- HELIX leaf additionally writes `Flyer_Row`, `Flyer_Column`.
+- `station_coord_source` by kind:
+  - `helix_experiment_log`: `spreadsheet_item_id`, `spreadsheet_row_index`, `spreadsheet_pdv_filename`
+  - `maxima_instructions`: `instructions_item_id`, `scan_point_index`
+  - `inherited`: `parent_item_id`, `parent_data_type`
+- **No IGSN is written** by the HELIX leaf despite its docstring (see §10).
+
+--
+
+## 7. Non-functional requirements
+
+- **NFR‑1 Idempotency** — re-running any pipeline is a no-op unless a meaningful
+  input changed (SPEC‑PROV‑02). Required because sweeps cover ~75k items against
+  a rate-limited API.
+- **NFR‑2 Safety** — dry-run default + STOPPED default (INV‑8).
+- **NFR‑3 Reproducibility** — provenance pins config hash + versions (SPEC‑PROV‑01/03).
+- **NFR‑4 Observability** — per-stage counts + advisory checks surfaced in the UI (C9).
+- **NFR‑5 Resilience** — per-item failure isolation (INV‑7); checks survive
+  unmaterialized partitions (SPEC‑ORCH‑03).
+- **NFR‑6 Scale** — indexed `/aimdl` queries instead of folder crawls; pagination
+  at 100/page.
+
+--
+
+## 8. Acceptance (end-to-end, from the test suite)
+
+- **AC‑1 (MAXIMA raw):** 25 `xrd_raw` + 25 `xrf_raw` → 50 enrichment writes + 1
+  manifest write; report sees 2 materialized raw partitions.
+  *(`test_coord_enrichment_e2e.py`.)*
+- **AC‑2 (inheritance):** 2 ALPSS + 1 `xrd_derived` → 3 writes + 1 manifest;
+  ALPSS Sample = parent Station via inherited version; coverage 1/1.
+  *(`test_coord_enrichment_phase4_e2e.py`.)*
+- **AC‑3 (HELIX boundary):** two rows, same station, timestamps straddling
+  2026‑04‑01 → v1 yields the flip, v2 yields identity.
+  *(`test_enriched_pdv_metadata_version_boundary_dispatch`.)*
+
+--
+
+## 9. Scope tiers — the decision the spec exists to support
+
+The capabilities above are all *real*, but they are not all *equally required for
+a first production cut*. This tiering separates "what the problem demands" from
+"what the current architecture chose." Use it to decide how much to keep.
+
+### Tier 0 — Minimal viable enrichment (HELIX leaf only)
+Covers: **C1, C2, C3.** Source: one spreadsheet → `pdv_trace` items (~3% of
+items). This is the slice that can honestly be expressed as *"partition by
+experiment-log; read a shot→x,y table; write coords."* Everything in C2/C3 (the
+versioned transform, provenance, idempotency) is still required even here — it is
+not optional gold-plating, because the deliverable is *Sample* coordinates and a
+reproducible record, not the raw spreadsheet number.
+*Open: can C1's 9 assets collapse to ~3? See Q1.*
+
+### Tier 1 — HELIX complete (add ALPSS derived)
+Adds: **C4.** Brings in ~18.8k derived items via inheritance + provenance
+tagging. Decision point: inherit-from-parent (current) **vs** match ALPSS files
+directly against the same spreadsheet shot table (their filenames carry IGSN +
+shot). See Q2.
+
+### Tier 2 — MAXIMA leaf (second instrument)
+Adds: **C5, C7 (discovery).** This is the part the "one spreadsheet table"
+mental model cannot express — MAXIMA has *no spreadsheet*; coordinates come from
+`instructions.txt`. This is genuinely new capability, not duplication.
+Decision point: dynamic partitions + discovery sensor (current) **vs** a periodic
+idempotent sweep. See Q3.
+
+### Tier 3 — MAXIMA derived + full reporting
+Adds: **C6, C8.** ~28k more derived items + state reporting/manifests.
+
+> **Reading the tiers against the simplification debate:** the engineer's 3-step
+> proposal is an accurate description of **Tier 0** (and an arguable Tier 1). It
+> is silent on Tiers 2–3, which are ~95% of items and have fundamentally
+> different sources. The right first question is not "is the code too complex?"
+> but "**which tier are we actually committing to ship first?**" — then cut
+> everything above that tier and simplify hard within it.
+
+--
+
+## 10. Open design questions
+
+- **Q1 — C1 granularity.** Can the 9-asset HELIX DAG collapse to read→match→write
+  (~3 assets)? `experiment_log_source` is a config shim; `validated_rows` /
+  `pdv_cross_references` are pure transforms split out only to host asset checks.
+  Tradeoff: fewer assets vs per-stage UI quality chips.
+- **Q2 — ALPSS coordinate source.** Inherit from parent (current, two-phase: tag
+  then inherit) vs match ALPSS filenames directly to the spreadsheet shot table.
+  Direct matching could remove the provenance-tagging asset and a whole job for
+  HELIX.
+- **Q3 — MAXIMA partitioning.** Is `MultiPartitionsDefinition` + dynamic dim +
+  discovery sensor + dual content-hash dedup warranted for ~26k items, or would a
+  periodic sweep relying on SPEC‑PROV‑02 idempotency be simpler to operate?
+  Dynamic partitions must be pre-registered and orphans accumulate.
+- **Q4 — Duplicate jobs.** `coord_enrichment_maxima_raw_job` and
+  `..._partition_job` select identical assets, split only for UI filterability.
+  Could be one job + tags.
+- **Q5 — Threshold config.** Rate thresholds (0.8/0.5/0.9) and rounding (4dp/1dp)
+  are inline literals. Centralize?
+- **Q6 — IGSN write policy.** Should the HELIX leaf write the IGSN it validated
+  (docstring claims it does; code does not)?
+- **Q7 — Namespacing.** Flat `Station_X/...` keys vs a nested `coordinates` dict.
+- **Q8 — Channel files.** Should one spreadsheet row enrich all channel files for
+  a shot, or only the unique match? (Today multi-match = ambiguous = skipped.)
+
+--
+
+## 11. Known spec ↔ code drift (surfaced during extraction)
+
+- **D1** — `enriched_pdv_metadata` docstring says it writes IGSN; it does not (Q6).
+- **D2** — `overwrite.should_write` docstring lists reason order differently from
+  the code's check order (`transform_version` is checked before
+  `station_coord_source`). No behavioral impact under current tests, which vary
+  one field at a time.
+- **D3** — `InstructionsCache` (`coord_enrichment/cache.py`) and the
+  `maxima.find_run_folder_id` / `fetch_instructions_for_run` folder-walking path
+  are **not wired into the leaf** (which self-fetches per partition). They are
+  exercised only by their own unit tests — leftovers from the pre‑issue‑#23
+  folder-walk design. Dead-relative-to-the-DAG; flag, don't delete blindly.
+- **D4** — `.claude/helix_dagster_context.md` describes an old `helix_dagster/`
+  module at version 0.2.0/0.4.0; the live package is `aimdl_coord_enrichment` at
+  0.6.0.
+
+--
+
+## 12. Traceability
+
+Every `SPEC‑*` requirement above cites the test(s) that currently pin it. The
+inverse map (test → requirement) can be generated from those citations. New
+behavior should add a `SPEC‑*` ID here first, then a test that references it.

--- a/docs/file_inventory.md
+++ b/docs/file_inventory.md
@@ -14,13 +14,20 @@ and a scratch probe (396) make up the rest.
 
 --
 
-## Flow 1 — Spreadsheet DAG (`process_helix_assets_job`)
+## Flow 1 — Spreadsheet flow (`process_helix_assets_job`)
+
+Three partitioned assets (`pdv_log → pdv_data → pdv_processing_manifest`),
+partitioned by the AIMD-L key `<igsn>//<experiment_date>`. Assets model
+durable external-state transitions; pure computation lives in
+`spreadsheet.py`.
 
 | File | Lines | Terminal output? |
 |---|---|---|
-| `aimdl_coord_enrichment/assets.py` | 528 | **Mixed** — 7 assets feed downstream; only `processing_manifest` is a sink |
-| `aimdl_coord_enrichment/checks.py` | 175 | **Yes** — asset checks, read-only, never feed a materialization |
-| **subtotal** | **703** | |
+| `aimdl_coord_enrichment/assets.py` | 245 | **Mixed** — `pdv_log`/`pdv_data` feed downstream; `pdv_processing_manifest` is a sink |
+| `aimdl_coord_enrichment/spreadsheet.py` | 279 | N/A — pure helpers (normalize, validate, match, write, summarize) |
+| `aimdl_coord_enrichment/partitions.py` | 16 | N/A — `HELIX_EXPERIMENT_LOG_PARTITIONS` definition |
+| `aimdl_coord_enrichment/checks.py` | 183 | **Yes** — asset checks, read-only, never feed a materialization |
+| **subtotal** | **723** | |
 
 ## Flow 2 — Coord-enrichment DAG
 
@@ -54,7 +61,7 @@ and a scratch probe (396) make up the rest.
 |---|---|---|
 | `aimdl_coord_enrichment/girder_io.py` | 231 | N/A — Girder read/write/query helpers |
 | `aimdl_coord_enrichment/__init__.py` | 194 | N/A — `Definitions` registry (both flows) |
-| `aimdl_coord_enrichment/sensors.py` | 162 | N/A — `helix_folder_sensor` + `maxima_raw_discovery_sensor` |
+| `aimdl_coord_enrichment/sensors.py` | 148 | N/A — `helix_experiment_log_discovery_sensor` + `maxima_raw_discovery_sensor` |
 | `aimdl_coord_enrichment/coordinates.py` | 104 | N/A — `transform_station_to_sample` (both DAGs) |
 | `aimdl_coord_enrichment/provenance.py` | 104 | N/A — `coord_provenance` builder (both DAGs) |
 | `aimdl_coord_enrichment/resources.py` | 67 | N/A — `GirderConnection` resource |
@@ -101,7 +108,7 @@ and a scratch probe (396) make up the rest.
 Five assets are true terminal sinks (read but never fed back into another
 materialization):
 
-- `processing_manifest` (in `assets.py`)
+- `pdv_processing_manifest` (in `assets.py`)
 - `enriched_helix_alpss` (`helix_alpss_leaf.py`)
 - `enriched_maxima_derived` (`maxima_derived_leaf.py`)
 - `coord_enrichment_manifest` (`manifest.py`)

--- a/docs/jobs_overview.md
+++ b/docs/jobs_overview.md
@@ -17,12 +17,12 @@ transform version.
 
 ## Job-by-job
 
-### 1. `process_helix_assets_job` — HELIX spreadsheet DAG
-- **Trigger:** `helix_folder_sensor` (polls the HELIX folder for new experiment-log spreadsheets).
-- **Partitioning:** none — one run per spreadsheet item.
-- **What it does:** Downloads a HELIX experiment-log spreadsheet, validates IGSNs, fetches the PDV trace inventory, matches PDV files to spreadsheet rows by filename, and **writes coordinate metadata to `pdv_trace` items**. Aggregates a quality report and stamps `meta.processing_status` back onto the source spreadsheet item.
+### 1. `process_helix_assets_job` — HELIX spreadsheet flow
+- **Trigger:** `helix_experiment_log_discovery_sensor` (polls `/aimdl/partition` for `pdv_experiment_log`, registers partitions, emits one partitioned RunRequest per changed log).
+- **Partitioning:** `HELIX_EXPERIMENT_LOG_PARTITIONS` = `DynamicPartitionsDefinition("helix_experiment_log")`, keyed on `<igsn>//<experiment_date>`.
+- **What it does:** Three durable partitioned assets — `pdv_log` (read + normalize + validate the experiment log), `pdv_data` (fetch the PDV trace inventory, match rows by filename, **write coordinate metadata to `pdv_trace` items**), `pdv_processing_manifest` (stamp `meta.processing_status` onto each source log item).
 - **Coordinate source:** each spreadsheet row's `Flyer_X/Y_Position_Corrected (mm)` becomes `Station_X/Y`; the row `Timestamp` selects the HELIX transform version.
-- **Writing asset:** `enriched_pdv_metadata` → `pdv_trace`.
+- **Writing asset:** `pdv_data` → `pdv_trace`.
 
 ### 2. `coord_enrichment_job` — state report (read-only)
 - **Trigger:** `coord_enrichment_state_report_schedule` (nightly 03:00 ET, ships STOPPED).
@@ -64,7 +64,7 @@ each HELIX and MAXIMA file type, and where those coordinates come from:
 
 | Instrument | `data_type` (Girder) | Role | Writing asset | Job | Coordinate source |
 |---|---|---|---|---|---|
-| HELIX | `pdv_trace` | leaf | `enriched_pdv_metadata` | `process_helix_assets_job` | Spreadsheet row `Flyer_X/Y_Position_Corrected` |
+| HELIX | `pdv_trace` | leaf | `pdv_data` | `process_helix_assets_job` | Spreadsheet row `Flyer_X/Y_Position_Corrected` |
 | HELIX | `pdv_alpss_output` | derived | `enriched_helix_alpss` | `coord_enrichment_helix_alpss_job` | Inherited from parent `pdv_trace` |
 | HELIX | `pdv_alpss_result` | derived | `enriched_helix_alpss` | `coord_enrichment_helix_alpss_job` | Inherited from parent `pdv_trace` |
 | HELIX | `pdv_alpss_results` | derived | `enriched_helix_alpss` | `coord_enrichment_helix_alpss_job` | Inherited from parent `pdv_trace` |

--- a/tests/test_annotations_rule.py
+++ b/tests/test_annotations_rule.py
@@ -21,6 +21,7 @@ FORBIDDEN_PATHS = [
     "aimdl_coord_enrichment/__init__.py",
     "aimdl_coord_enrichment/assets.py",
     "aimdl_coord_enrichment/checks.py",
+    "aimdl_coord_enrichment/partitions.py",
     "aimdl_coord_enrichment/resources.py",
     "aimdl_coord_enrichment/sensors.py",
     "aimdl_coord_enrichment/instruments/__init__.py",

--- a/tests/test_asset_groups.py
+++ b/tests/test_asset_groups.py
@@ -12,17 +12,11 @@ style of `tests/test_annotations_rule.py`.
 
 from aimdl_coord_enrichment import defs
 
-# Asset key -> expected group_name. 18 assets across 6 groups.
+# Asset key -> expected group_name. 12 assets across 6 groups.
 EXPECTED_GROUPS = {
-    "experiment_log_source": "helix_spreadsheet",
-    "raw_experiment_log": "helix_spreadsheet",
-    "pdv_trace_inventory": "helix_spreadsheet",
-    "validated_rows": "helix_spreadsheet",
-    "pdv_cross_references": "helix_spreadsheet",
-    "enriched_pdv_metadata": "helix_spreadsheet",
-    "alpss_results_inventory": "helix_spreadsheet",
-    "quality_report": "helix_spreadsheet",
-    "processing_manifest": "helix_spreadsheet",
+    "pdv_log": "helix_spreadsheet",
+    "pdv_data": "helix_spreadsheet",
+    "pdv_processing_manifest": "helix_spreadsheet",
     "helix_alpss_provenance_tagged": "helix_alpss",
     "enriched_helix_alpss": "helix_alpss",
     "enriched_maxima_raw": "maxima_raw",
@@ -35,7 +29,7 @@ EXPECTED_GROUPS = {
 }
 
 EXPECTED_COUNTS = {
-    "helix_spreadsheet": 9,
+    "helix_spreadsheet": 3,
     "helix_alpss": 2,
     "maxima_raw": 1,
     "maxima_derived": 1,

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -1,6 +1,6 @@
-"""Integration tests for the Dagster asset-based pipeline."""
+"""Integration tests for the 3-asset partitioned helix_spreadsheet flow."""
 
-from datetime import datetime, timezone
+import io
 from unittest.mock import MagicMock
 
 import pandas as pd
@@ -8,291 +8,117 @@ import pytest
 from dagster import build_asset_context
 
 from aimdl_coord_enrichment.assets import (
-    validated_rows as validated_rows_fn,
-    pdv_cross_references as pdv_cross_references_fn,
+    pdv_data as pdv_data_fn,
+    pdv_log as pdv_log_fn,
+    pdv_processing_manifest as pdv_processing_manifest_fn,
 )
 from aimdl_coord_enrichment.coordinates import _COORD_TRANSFORMER
 
-
-def test_validated_rows_pure():
-    """Call validated_rows asset function directly with a sample DataFrame."""
-    df = pd.DataFrame(
-        [
-            {"Sample_IGSN": "ABCDEF12345", "PDV_FileName": "shot001"},
-            {"Sample_IGSN": "INVALID", "PDV_FileName": "shot002"},
-            {"Sample_IGSN": float("nan"), "PDV_FileName": "shot003"},
-            {"Sample_IGSN": "XYZABC67890-sub1", "PDV_FileName": "shot004"},
-        ]
-    )
-
-    ctx = build_asset_context()
-    result = validated_rows_fn(context=ctx, raw_experiment_log=df)
-
-    out_df = result["dataframe"]
-    issues = result["igsn_issues"]
-
-    # Row 0: valid IGSN
-    assert out_df.loc[0, "valid_igsn"] == "ABCDEF12345"
-    # Row 1: invalid format
-    assert pd.isna(out_df.loc[1, "valid_igsn"])
-    # Row 2: missing (NaN)
-    assert pd.isna(out_df.loc[2, "valid_igsn"])
-    # Row 3: valid with suffix
-    assert out_df.loc[3, "valid_igsn"] == "XYZABC67890-sub1"
-
-    # Should have 2 issues: invalid_format + missing
-    assert len(issues) == 2
-    issue_types = {i["issue"] for i in issues}
-    assert "invalid_format" in issue_types
-    assert "missing" in issue_types
+PARTITION_KEY = "ABCDEF12345//2026-04-16"
 
 
-def test_pdv_cross_references_pure():
-    """Call pdv_cross_references asset function with mock inputs."""
-    df = pd.DataFrame(
-        [
-            {"Sample_IGSN": "ABCDEF12345", "PDV_FileName": "shot001", "valid_igsn": "ABCDEF12345"},
-            {"Sample_IGSN": "ABCDEF12346", "PDV_FileName": "shot999", "valid_igsn": "ABCDEF12346"},
-            {"Sample_IGSN": "ABCDEF12347", "PDV_FileName": float("nan"), "valid_igsn": "ABCDEF12347"},
-        ]
-    )
+def _raw_log_csv():
+    """A small experiment-log CSV using raw (pre-COLUMN_MAP) column names."""
+    df = pd.DataFrame([
+        {
+            "Timestamp": "2026-04-16T17:00:00+00:00",
+            "Sample_ID": "ABCDEF12345",
+            "PDV_FileName": "shot001",
+            "Flyer_Row": 1,
+            "Flyer_Column": 2,
+            "Flyer_X_Position_Corrected (mm)": 10.5,
+            "Flyer_Y_Position_Corrected (mm)": 20.3,
+        },
+        {
+            "Timestamp": "2026-04-16T17:05:00+00:00",
+            "Sample_ID": "INVALID",
+            "PDV_FileName": "shot999",
+            "Flyer_Row": 1,
+            "Flyer_Column": 3,
+            "Flyer_X_Position_Corrected (mm)": 11.0,
+            "Flyer_Y_Position_Corrected (mm)": 21.0,
+        },
+    ])
+    buf = io.StringIO()
+    df.to_csv(buf, index=False)
+    return buf.getvalue().encode("utf-8")
 
-    pdv_items = [
-        {"name": "shot001_ch1.tdms", "_id": "a1", "meta": {"igsn": "ABCDEF12345", "data_type": "pdv_trace"}},
-        {"name": "shot002_ch1.tdms", "_id": "b1", "meta": {"igsn": "ABCDEF12346", "data_type": "pdv_trace"}},
-    ]
 
-    validated = {"dataframe": df, "igsn_issues": []}
+def _mock_girder(log_items, pdv_items):
+    """MagicMock girder dispatching .get on path + .downloadFile + .addMetadataToItem."""
+    client = MagicMock()
+    csv_bytes = _raw_log_csv()
 
-    ctx = build_asset_context()
-    result = pdv_cross_references_fn(
-        context=ctx,
-        validated_rows=validated,
-        pdv_trace_inventory=pdv_items,
-    )
+    def fake_get(path, parameters=None):
+        if path == "aimdl/partition/details":
+            return log_items
+        if path == "aimdl/datafiles":
+            return pdv_items
+        if path.startswith("item/") and path.endswith("/files"):
+            item_id = path.split("/")[1]
+            return [{"_id": f"file-{item_id}"}]
+        raise AssertionError(f"unexpected client.get: {path} {parameters}")
 
-    matches = result["matches"]
-    issues = result["pdv_issues"]
+    def fake_download(file_id, buf):
+        buf.write(csv_bytes)
 
-    # Row 0 matched shot001
-    assert 0 in matches
-    assert matches[0]["_id"] == "a1"
-
-    # Row 1 not found
-    assert 1 not in matches
-
-    # Row 2 skipped (NaN filename) — no match, no issue
-    assert 2 not in matches
-
-    # Only one issue: not_found for row 1
-    assert len(issues) == 1
-    assert issues[0]["type"] == "not_found"
-    assert issues[0]["row"] == 1
+    client.get.side_effect = fake_get
+    client.downloadFile.side_effect = fake_download
+    return client
 
 
 def test_asset_dag_loads():
-    """Verify the Dagster Definitions object loads with all assets and checks."""
+    """Verify the Dagster Definitions object loads with the 3 assets and checks."""
     from aimdl_coord_enrichment import defs
 
     repo = defs.get_repository_def()
     asset_keys = {ak.to_user_string() for ak in repo.asset_graph.get_all_asset_keys()}
 
-    expected_assets = {
-        "experiment_log_source",
-        "raw_experiment_log",
-        "pdv_trace_inventory",
-        "validated_rows",
-        "pdv_cross_references",
-        "enriched_pdv_metadata",
-        "alpss_results_inventory",
-        "quality_report",
-        "processing_manifest",
-    }
+    expected_assets = {"pdv_log", "pdv_data", "pdv_processing_manifest"}
     for name in expected_assets:
         assert name in asset_keys, f"Missing asset: {name}"
 
-    # Verify asset checks are registered
-    check_keys = {
-        str(ck) for ck in repo.asset_graph.asset_check_keys
-    }
+    # Old assets must be gone.
+    for gone in ("experiment_log_source", "raw_experiment_log", "validated_rows",
+                 "pdv_cross_references", "enriched_pdv_metadata",
+                 "alpss_results_inventory", "quality_report", "processing_manifest"):
+        assert gone not in asset_keys, f"Old asset still present: {gone}"
+
+    check_keys = {str(ck) for ck in repo.asset_graph.asset_check_keys}
     assert len(check_keys) >= 5, f"Expected at least 5 asset checks, got {len(check_keys)}"
 
 
-def test_helix_folder_sensor_run_config_validates():
-    """The sensor's RunRequest must validate against process_helix_assets_job.
+def test_pdv_log_reads_partition():
+    """pdv_log fetches log items for its partition, normalizes, validates IGSNs."""
+    log_items = [{"_id": "logitem1", "name": "log.csv"}]
+    girder = _mock_girder(log_items, pdv_items=[])
 
-    Regression test for the bug where helix_folder_sensor configured
-    only `raw_experiment_log` while three ops took ExperimentLogConfig.
-    """
-    from dagster import validate_run_config
-    from aimdl_coord_enrichment import defs
+    ctx = build_asset_context(partition_key=PARTITION_KEY)
+    result = pdv_log_fn(context=ctx, girder=girder)
 
-    job = defs.resolve_job_def("process_helix_assets_job")
-
-    # Reproduce the exact run_config shape the sensor emits.
-    run_config = {
-        "ops": {
-            "experiment_log_source": {
-                "config": {
-                    "item_id": "fake_id_for_validation",
-                    "filename": "anything.csv",
-                }
-            }
-        }
-    }
-    # Will raise DagsterInvalidConfigError on shape mismatch.
-    validate_run_config(job, run_config)
+    assert result["partition_key"] == PARTITION_KEY
+    assert result["source_item_ids"] == ["logitem1"]
+    df = result["dataframe"]
+    # COLUMN_MAP applied: Sample_ID -> Sample_IGSN, Corrected -> Final_mm
+    assert "Sample_IGSN" in df.columns
+    assert "Flyer_X_Position_Final_mm" in df.columns
+    assert "valid_igsn" in df.columns
+    # Row 0 valid, row 1 invalid
+    assert df.loc[0, "valid_igsn"] == "ABCDEF12345"
+    assert pd.isna(df.loc[1, "valid_igsn"])
+    assert df.loc[0, "_source_item_id"] == "logitem1"
+    # One invalid_format IGSN issue
+    assert len(result["igsn_issues"]) == 1
 
 
-def test_igsn_mismatch_detection():
-    """Verify that IGSN mismatches between spreadsheet and Girder item are flagged."""
-    df = pd.DataFrame([
-        {"Sample_IGSN": "ABCDEF12345", "PDV_FileName": "shot001",
-         "valid_igsn": "ABCDEF12345"},
-    ])
-    pdv_items = [
-        {"name": "shot001_ch1.tdms", "_id": "a1",
-         "meta": {"igsn": "XXXXXX99999", "data_type": "pdv_trace"}},
-    ]
-    validated = {"dataframe": df, "igsn_issues": []}
-    ctx = build_asset_context()
-    result = pdv_cross_references_fn(
-        context=ctx,
-        validated_rows=validated,
-        pdv_trace_inventory=pdv_items,
-    )
-    issues = result["pdv_issues"]
-    mismatch_issues = [i for i in issues if i["type"] == "igsn_mismatch"]
-    assert len(mismatch_issues) == 1
-    assert mismatch_issues[0]["spreadsheet_igsn"] == "ABCDEF12345"
-    assert mismatch_issues[0]["item_igsn"] == "XXXXXX99999"
-
-
-def test_quality_report_alpss_completeness():
-    """Verify quality_report includes ALPSS completeness metrics."""
-    df = pd.DataFrame([
-        {"Sample_IGSN": "ABCDEF12345", "PDV_FileName": "shot001",
-         "valid_igsn": "ABCDEF12345"},
-        {"Sample_IGSN": "ABCDEF12346", "PDV_FileName": "shot002",
-         "valid_igsn": "ABCDEF12346"},
-    ])
-    validated = {"dataframe": df, "igsn_issues": []}
-    pdv_xrefs = {
-        "matches": {0: {"_id": "a1"}, 1: {"_id": "b1"}},
-        "pdv_issues": [],
-    }
-    enriched = {"written_count": 2, "write_errors": [], "coord_failures": 0}
-    alpss_items = [
-        {"meta": {"igsn": "ABCDEF12345", "data_type": "pdv_alpss_result"}},
-        # ABCDEF12346 has no ALPSS result
-    ]
-
-    ctx = build_asset_context()
-    from aimdl_coord_enrichment.assets import quality_report as quality_report_fn
-    report = quality_report_fn(
-        context=ctx,
-        validated_rows=validated,
-        pdv_cross_references=pdv_xrefs,
-        enriched_pdv_metadata=enriched,
-        alpss_results_inventory=alpss_items,
-    )
-    assert report["alpss_completeness"]["igsns_with_alpss_results"] == 1
-    assert report["alpss_completeness"]["igsns_without_alpss_results"] == 1
-    assert "ABCDEF12346" in report["alpss_completeness"]["missing_igsns"]
-    assert report["summary"]["alpss_coverage_pct"] == 50.0
-
-
-def test_processing_manifest_clean():
-    """Test manifest for a run with no issues."""
-    from unittest.mock import MagicMock
-    from aimdl_coord_enrichment.assets import processing_manifest as manifest_fn
-
-    df = pd.DataFrame([
-        {"Sample_IGSN": "ABCDEF12345", "PDV_FileName": "shot001",
-         "valid_igsn": "ABCDEF12345"},
-    ])
-    validated = {"dataframe": df, "igsn_issues": []}
-    xrefs = {"matches": {0: {"_id": "a1"}}, "pdv_issues": []}
-    enriched = {"written_count": 1, "write_errors": [], "coord_failures": 0}
-    report = {"igsn_issues": [], "pdv_issues": [], "write_errors": [],
-              "alpss_completeness": {"matched_igsns": 1, "igsns_with_alpss_results": 1,
-                                     "igsns_without_alpss_results": 0, "missing_igsns": []},
-              "summary": {"total_igsn_issues": 0, "total_pdv_issues": 0,
-                          "total_write_errors": 0, "alpss_coverage_pct": 100.0}}
-
-    source = {"item_id": "test_item_123", "filename": "test.csv"}
-    mock_girder = MagicMock()
-
-    ctx = build_asset_context()
-    result = manifest_fn(
-        context=ctx,
-        experiment_log_source=source,
-        quality_report=report,
-        validated_rows=validated,
-        pdv_cross_references=xrefs,
-        enriched_pdv_metadata=enriched,
-        girder=mock_girder,
-    )
-
-    assert result["status"] == "completed_clean"
-    assert result["total_rows"] == 1
-    assert result["rows_enriched"] == 1
-    assert result["issues_summary"]["igsn_invalid"] == 0
-    mock_girder.addMetadataToItem.assert_called_once()
-
-
-def test_processing_manifest_with_warnings():
-    """Test manifest for a run with issues."""
-    from unittest.mock import MagicMock
-    from aimdl_coord_enrichment.assets import processing_manifest as manifest_fn
-
-    df = pd.DataFrame([
-        {"Sample_IGSN": "INVALID", "PDV_FileName": "shot001",
-         "valid_igsn": None},
-    ])
-    validated = {
-        "dataframe": df,
-        "igsn_issues": [{"issue": "invalid_format", "value": "INVALID", "row": 0}],
-    }
-    xrefs = {"matches": {}, "pdv_issues": [{"type": "not_found", "row": 0}]}
-    enriched = {"written_count": 0, "write_errors": [], "coord_failures": 0}
-    report = {"igsn_issues": validated["igsn_issues"],
-              "pdv_issues": xrefs["pdv_issues"], "write_errors": [],
-              "alpss_completeness": {"matched_igsns": 0, "igsns_with_alpss_results": 0,
-                                     "igsns_without_alpss_results": 0, "missing_igsns": []},
-              "summary": {"alpss_coverage_pct": 0.0}}
-
-    source = {"item_id": "test_item_456", "filename": "test.csv"}
-    mock_girder = MagicMock()
-
-    ctx = build_asset_context()
-    result = manifest_fn(
-        context=ctx,
-        experiment_log_source=source,
-        quality_report=report,
-        validated_rows=validated,
-        pdv_cross_references=xrefs,
-        enriched_pdv_metadata=enriched,
-        girder=mock_girder,
-    )
-
-    assert result["status"] == "completed_with_warnings"
-    assert result["issues_summary"]["igsn_invalid"] == 1
-    assert result["issues_summary"]["pdv_not_found"] == 1
-
-
-def test_enriched_pdv_metadata_writes_provenance():
-    """Verify enriched_pdv_metadata writes coord_provenance alongside coords."""
+def test_pdv_data_matches_and_writes():
+    """pdv_data fetches inventory, matches rows, writes coord metadata."""
     if _COORD_TRANSFORMER is None:
         pytest.skip("CoordinateTransformer unavailable (YAML missing)")
 
-    from aimdl_coord_enrichment.assets import (
-        enriched_pdv_metadata as enrich_fn,
-    )
-
     df = pd.DataFrame([
         {
-            "Timestamp": datetime(2026, 4, 1, 12, 0, 0, tzinfo=timezone.utc),
+            "Timestamp": "2026-04-16T17:00:00+00:00",
             "Sample_IGSN": "ABCDEF12345",
             "valid_igsn": "ABCDEF12345",
             "PDV_FileName": "shot001",
@@ -300,136 +126,146 @@ def test_enriched_pdv_metadata_writes_provenance():
             "Flyer_Column": 2,
             "Flyer_X_Position_Final_mm": 10.5,
             "Flyer_Y_Position_Final_mm": 20.3,
+            "_source_item_id": "logitem1",
         },
     ])
-    validated = {"dataframe": df, "igsn_issues": []}
-    xrefs = {
-        "matches": {
-            0: {"_id": "pdvitem1", "name": "shot001_ch1.tdms",
-                "meta": {"igsn": "ABCDEF12345", "data_type": "pdv_trace"}},
-        },
-        "pdv_issues": [],
+    pdv_log = {
+        "dataframe": df,
+        "igsn_issues": [],
+        "source_item_ids": ["logitem1"],
+        "partition_key": PARTITION_KEY,
     }
-    source = {"item_id": "src_spreadsheet_id", "filename": "test.csv"}
-    mock_girder = MagicMock()
+    pdv_items = [
+        {"name": "shot001_ch1.tdms", "_id": "pdvitem1",
+         "meta": {"igsn": "ABCDEF12345", "data_type": "pdv_trace"}},
+    ]
+    girder = _mock_girder(log_items=[], pdv_items=pdv_items)
 
-    ctx = build_asset_context()
-    result = enrich_fn(
-        context=ctx,
-        experiment_log_source=source,
-        pdv_cross_references=xrefs,
-        validated_rows=validated,
-        girder=mock_girder,
-    )
+    ctx = build_asset_context(partition_key=PARTITION_KEY)
+    result = pdv_data_fn(context=ctx, pdv_log=pdv_log, girder=girder)
 
-    mock_girder.addMetadataToItem.assert_called_once()
-    call_args = mock_girder.addMetadataToItem.call_args
-    item_id_arg, payload = call_args[0]
-    assert item_id_arg == "pdvitem1"
-    assert "Station_X" in payload
-    assert "Sample_X" in payload
-    assert "coord_provenance" in payload
-    prov = payload["coord_provenance"]
-    assert prov["instrument"] == "HELIX"
-    assert prov["transform_version"] is not None
-    assert prov["station_coord_source"]["kind"] == "helix_experiment_log"
-    assert prov["station_coord_source"]["spreadsheet_item_id"] == "src_spreadsheet_id"
-    assert prov["station_coord_source"]["spreadsheet_row_index"] == 0
-
-    assert result["naive_timestamps_count"] == 0
+    assert result["inventory_count"] == 1
+    assert result["matched_count"] == 1
+    assert result["rows_with_pdv"] == 1
     assert result["written_count"] == 1
+    assert result["pdv_issues"] == []
     assert result["version_counter"]
+    girder.addMetadataToItem.assert_called_once()
+    item_id_arg, payload = girder.addMetadataToItem.call_args[0]
+    assert item_id_arg == "pdvitem1"
+    assert "Sample_X" in payload
+    assert payload["coord_provenance"]["station_coord_source"]["spreadsheet_item_id"] == "logitem1"
 
 
-def test_enriched_pdv_metadata_version_boundary_dispatch():
-    """Two rows with identical station coords and different timestamps
-    straddling HELIX v1/v2 must produce different Sample_X/Y values.
-    """
-    import pytest
-    from datetime import datetime, timezone
-    from unittest.mock import MagicMock
-    from dagster import build_asset_context
-    from aimdl_coord_enrichment.assets import (
-        enriched_pdv_metadata as enriched_fn,
+def test_pdv_processing_manifest_writes_status():
+    """pdv_processing_manifest summarizes and writes meta.processing_status."""
+    df = pd.DataFrame([{"valid_igsn": "ABCDEF12345"}])
+    pdv_log = {
+        "dataframe": df,
+        "igsn_issues": [],
+        "source_item_ids": ["logitem1"],
+        "partition_key": PARTITION_KEY,
+    }
+    pdv_data = {
+        "pdv_issues": [],
+        "write_errors": [],
+        "matched_count": 1,
+        "written_count": 1,
+        "coord_failures": 0,
+    }
+    girder = MagicMock()
+
+    ctx = build_asset_context(partition_key=PARTITION_KEY)
+    result = pdv_processing_manifest_fn(
+        context=ctx, pdv_log=pdv_log, pdv_data=pdv_data, girder=girder
     )
-    from aimdl_coord_enrichment.coordinates import _COORD_TRANSFORMER
 
+    assert result["status"] == "completed_clean"
+    assert result["manifest_written"] is True
+    girder.addMetadataToItem.assert_called_once()
+    item_id_arg, payload = girder.addMetadataToItem.call_args[0]
+    assert item_id_arg == "logitem1"
+    assert "processing_status" in payload
+
+
+def test_pdv_processing_manifest_flags_write_failure():
+    """manifest_written is False when a source-item write raises."""
+    df = pd.DataFrame([{"valid_igsn": "ABCDEF12345"}])
+    pdv_log = {
+        "dataframe": df,
+        "igsn_issues": [],
+        "source_item_ids": ["logitem1"],
+        "partition_key": PARTITION_KEY,
+    }
+    pdv_data = {
+        "pdv_issues": [],
+        "write_errors": [],
+        "matched_count": 1,
+        "written_count": 1,
+        "coord_failures": 0,
+    }
+    girder = MagicMock()
+    girder.addMetadataToItem.side_effect = RuntimeError("girder down")
+
+    ctx = build_asset_context(partition_key=PARTITION_KEY)
+    result = pdv_processing_manifest_fn(
+        context=ctx, pdv_log=pdv_log, pdv_data=pdv_data, girder=girder
+    )
+    assert result["manifest_written"] is False
+
+
+def test_pdv_data_version_boundary_dispatch():
+    """Two rows with identical station coords and timestamps straddling the
+    HELIX v1/v2 boundary must produce different Sample_X/Y values.
+    """
     if _COORD_TRANSFORMER is None:
         pytest.skip("COORD_TRANSFORMS_YAML not available")
 
-    # Two rows: same station coords, different timestamps.
-    # Pick an (x,y) where v1 and v2 predict clearly different outputs.
-    # Station (8, 8):  v1 -> (32, 8);  v2 -> (8, 8).
+    # Station (8, 8): v1 -> (32, 8); v2 -> (8, 8).
     df = pd.DataFrame([
         {
             "Timestamp": "2025-06-01T12:00:00+00:00",  # pre-2026-04-01 -> v1
             "Sample_IGSN": "ABCDEF00001",
             "valid_igsn": "ABCDEF00001",
             "PDV_FileName": "shot_v1_ch1",
-            "Flyer_Row": 1,
-            "Flyer_Column": 1,
             "Flyer_X_Position_Final_mm": 8.0,
             "Flyer_Y_Position_Final_mm": 8.0,
+            "_source_item_id": "logitem1",
         },
         {
             "Timestamp": "2026-05-01T12:00:00+00:00",  # post-boundary -> v2
             "Sample_IGSN": "ABCDEF00002",
             "valid_igsn": "ABCDEF00002",
             "PDV_FileName": "shot_v2_ch1",
-            "Flyer_Row": 1,
-            "Flyer_Column": 2,
             "Flyer_X_Position_Final_mm": 8.0,
             "Flyer_Y_Position_Final_mm": 8.0,
+            "_source_item_id": "logitem1",
         },
     ])
-
-    validated = {"dataframe": df, "igsn_issues": []}
-    matches = {
-        0: {"_id": "itemv1", "meta": {"igsn": "ABCDEF00001"}, "name": "shot_v1_ch1.csv"},
-        1: {"_id": "itemv2", "meta": {"igsn": "ABCDEF00002"}, "name": "shot_v2_ch1.csv"},
+    pdv_log = {
+        "dataframe": df,
+        "igsn_issues": [],
+        "source_item_ids": ["logitem1"],
+        "partition_key": PARTITION_KEY,
     }
-    xrefs = {"matches": matches, "pdv_issues": []}
-
+    pdv_items = [
+        {"_id": "itemv1", "meta": {"igsn": "ABCDEF00001"}, "name": "shot_v1_ch1.csv"},
+        {"_id": "itemv2", "meta": {"igsn": "ABCDEF00002"}, "name": "shot_v2_ch1.csv"},
+    ]
     captured = []
-    mock_girder = MagicMock()
-    mock_girder.addMetadataToItem.side_effect = lambda item_id, meta: captured.append(
+    girder = _mock_girder(log_items=[], pdv_items=pdv_items)
+    girder.addMetadataToItem.side_effect = lambda item_id, meta: captured.append(
         (item_id, meta)
     )
 
-    source = {"item_id": "src_sheet_item", "filename": "test.csv"}
-    ctx = build_asset_context()
-    result = enriched_fn(
-        context=ctx,
-        experiment_log_source=source,
-        pdv_cross_references=xrefs,
-        validated_rows=validated,
-        girder=mock_girder,
-    )
+    ctx = build_asset_context(partition_key=PARTITION_KEY)
+    result = pdv_data_fn(context=ctx, pdv_log=pdv_log, girder=girder)
 
     assert result["written_count"] == 2
-    assert len(captured) == 2
-
     by_id = {iid: m for iid, m in captured}
-    v1_payload = by_id["itemv1"]
-    v2_payload = by_id["itemv2"]
-
-    # Provenance records the resolved version per row
-    assert "v1" in v1_payload["coord_provenance"]["transform_version"]
-    assert "v2" in v2_payload["coord_provenance"]["transform_version"]
-
-    # Same inputs, different transforms → different Sample_X/Y
-    assert (v1_payload["Sample_X"], v1_payload["Sample_Y"]) != (
-        v2_payload["Sample_X"],
-        v2_payload["Sample_Y"],
-    )
-
-    # Exact values per the YAML calibration points.
-    # Station (8, 8): v1 -> (32, 8),  v2 -> (8, 8)
-    assert v1_payload["Sample_X"] == pytest.approx(32.0, abs=1e-4)
-    assert v1_payload["Sample_Y"] == pytest.approx(8.0, abs=1e-4)
-    assert v2_payload["Sample_X"] == pytest.approx(8.0, abs=1e-4)
-    assert v2_payload["Sample_Y"] == pytest.approx(8.0, abs=1e-4)
-
-    # The asset's version_counter should reflect both versions
+    assert "v1" in by_id["itemv1"]["coord_provenance"]["transform_version"]
+    assert "v2" in by_id["itemv2"]["coord_provenance"]["transform_version"]
+    assert by_id["itemv1"]["Sample_X"] == pytest.approx(32.0, abs=1e-4)
+    assert by_id["itemv2"]["Sample_X"] == pytest.approx(8.0, abs=1e-4)
     assert result["version_counter"].get("HELIX/v1", 0) == 1
     assert result["version_counter"].get("HELIX/v2", 0) == 1

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -8,11 +8,15 @@ import pytest
 from dagster import build_asset_context
 
 from aimdl_coord_enrichment.assets import (
+    HelixSpreadsheetConfig,
     pdv_data as pdv_data_fn,
     pdv_log as pdv_log_fn,
     pdv_processing_manifest as pdv_processing_manifest_fn,
 )
 from aimdl_coord_enrichment.coordinates import _COORD_TRANSFORMER
+
+LIVE = HelixSpreadsheetConfig(dry_run=False)
+DRY = HelixSpreadsheetConfig(dry_run=True)
 
 PARTITION_KEY = "ABCDEF12345//2026-04-16"
 
@@ -142,7 +146,7 @@ def test_pdv_data_matches_and_writes():
     girder = _mock_girder(log_items=[], pdv_items=pdv_items)
 
     ctx = build_asset_context(partition_key=PARTITION_KEY)
-    result = pdv_data_fn(context=ctx, pdv_log=pdv_log, girder=girder)
+    result = pdv_data_fn(context=ctx, config=LIVE, pdv_log=pdv_log, girder=girder)
 
     assert result["inventory_count"] == 1
     assert result["matched_count"] == 1
@@ -177,7 +181,7 @@ def test_pdv_processing_manifest_writes_status():
 
     ctx = build_asset_context(partition_key=PARTITION_KEY)
     result = pdv_processing_manifest_fn(
-        context=ctx, pdv_log=pdv_log, pdv_data=pdv_data, girder=girder
+        context=ctx, config=LIVE, pdv_log=pdv_log, pdv_data=pdv_data, girder=girder
     )
 
     assert result["status"] == "completed_clean"
@@ -209,7 +213,7 @@ def test_pdv_processing_manifest_flags_write_failure():
 
     ctx = build_asset_context(partition_key=PARTITION_KEY)
     result = pdv_processing_manifest_fn(
-        context=ctx, pdv_log=pdv_log, pdv_data=pdv_data, girder=girder
+        context=ctx, config=LIVE, pdv_log=pdv_log, pdv_data=pdv_data, girder=girder
     )
     assert result["manifest_written"] is False
 
@@ -259,7 +263,7 @@ def test_pdv_data_version_boundary_dispatch():
     )
 
     ctx = build_asset_context(partition_key=PARTITION_KEY)
-    result = pdv_data_fn(context=ctx, pdv_log=pdv_log, girder=girder)
+    result = pdv_data_fn(context=ctx, config=LIVE, pdv_log=pdv_log, girder=girder)
 
     assert result["written_count"] == 2
     by_id = {iid: m for iid, m in captured}
@@ -269,3 +273,74 @@ def test_pdv_data_version_boundary_dispatch():
     assert by_id["itemv2"]["Sample_X"] == pytest.approx(8.0, abs=1e-4)
     assert result["version_counter"].get("HELIX/v1", 0) == 1
     assert result["version_counter"].get("HELIX/v2", 0) == 1
+
+
+def test_pdv_data_dry_run_skips_writes():
+    """With dry_run=True, pdv_data computes but performs no Girder writes."""
+    if _COORD_TRANSFORMER is None:
+        pytest.skip("CoordinateTransformer unavailable (YAML missing)")
+
+    df = pd.DataFrame([
+        {
+            "Timestamp": "2026-04-16T17:00:00+00:00",
+            "Sample_IGSN": "ABCDEF12345",
+            "valid_igsn": "ABCDEF12345",
+            "PDV_FileName": "shot001",
+            "Flyer_X_Position_Final_mm": 10.5,
+            "Flyer_Y_Position_Final_mm": 20.3,
+            "_source_item_id": "logitem1",
+        },
+    ])
+    pdv_log = {
+        "dataframe": df,
+        "igsn_issues": [],
+        "source_item_ids": ["logitem1"],
+        "partition_key": PARTITION_KEY,
+    }
+    pdv_items = [
+        {"name": "shot001_ch1.tdms", "_id": "pdvitem1",
+         "meta": {"igsn": "ABCDEF12345", "data_type": "pdv_trace"}},
+    ]
+    girder = _mock_girder(log_items=[], pdv_items=pdv_items)
+
+    ctx = build_asset_context(partition_key=PARTITION_KEY)
+    result = pdv_data_fn(context=ctx, config=DRY, pdv_log=pdv_log, girder=girder)
+
+    girder.addMetadataToItem.assert_not_called()
+    assert result["dry_run"] is True
+    assert result["matched_count"] == 1
+    assert result["written_count"] == 0
+    assert result["simulated_count"] == 1
+    # Transform still computed even though nothing was written.
+    assert result["version_counter"]
+
+
+def test_pdv_processing_manifest_dry_run_skips_write():
+    """With dry_run=True, the manifest is computed but not written; the
+    representative manifest_written flag is still True."""
+    df = pd.DataFrame([{"valid_igsn": "ABCDEF12345"}])
+    pdv_log = {
+        "dataframe": df,
+        "igsn_issues": [],
+        "source_item_ids": ["logitem1"],
+        "partition_key": PARTITION_KEY,
+    }
+    pdv_data = {
+        "pdv_issues": [],
+        "write_errors": [],
+        "matched_count": 1,
+        "written_count": 0,
+        "simulated_count": 1,
+        "coord_failures": 0,
+    }
+    girder = MagicMock()
+
+    ctx = build_asset_context(partition_key=PARTITION_KEY)
+    result = pdv_processing_manifest_fn(
+        context=ctx, config=DRY, pdv_log=pdv_log, pdv_data=pdv_data, girder=girder
+    )
+
+    girder.addMetadataToItem.assert_not_called()
+    assert result["dry_run"] is True
+    assert result["manifest_written"] is True
+    assert result["status"] == "completed_clean"

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -1,171 +1,158 @@
-"""Tests for the retargeted helix_spreadsheet asset checks.
+"""Tests for the helix_spreadsheet asset-check decision helpers.
 
-Each check now reads a single asset's bundled output dict (pdv_log,
-pdv_data, or pdv_processing_manifest).
+The checks read each partition's latest materialization metadata from the
+event log (see checks.py / check_support.py) and delegate the verdict to
+these pure helpers, which take a flat metadata dict. Testing the helpers
+directly keeps the data logic covered without standing up an instance.
 """
 
-import pandas as pd
-from dagster import build_asset_context
-
 from aimdl_coord_enrichment.checks import (
-    coord_transform_check,
-    enrichment_success_rate,
-    igsn_consistency,
-    igsn_validity_rate,
-    manifest_written,
-    pdv_match_rate,
-    zero_pdv_inventory,
+    eval_coord_transform,
+    eval_enrichment_success_rate,
+    eval_igsn_consistency,
+    eval_igsn_validity,
+    eval_manifest_written,
+    eval_pdv_match_rate,
+    eval_zero_inventory,
 )
 
 
-def test_zero_pdv_inventory_fails_on_empty():
-    ctx = build_asset_context()
-    result = zero_pdv_inventory(ctx, pdv_data={"inventory_count": 0})
+def test_zero_inventory_fails_on_empty():
+    result = eval_zero_inventory({"inventory_count": 0})
     assert not result.passed
     assert result.severity.value == "ERROR"
 
 
-def test_zero_pdv_inventory_passes_with_items():
-    ctx = build_asset_context()
-    result = zero_pdv_inventory(ctx, pdv_data={"inventory_count": 5})
+def test_zero_inventory_passes_with_items():
+    result = eval_zero_inventory({"inventory_count": 5})
     assert result.passed
 
 
 def test_igsn_validity_rate_passes_above_threshold():
-    ctx = build_asset_context()
-    pdv_log = {"dataframe": pd.DataFrame({"valid_igsn": ["A", "B", "C", "D", None]})}
-    result = igsn_validity_rate(ctx, pdv_log=pdv_log)
+    result = eval_igsn_validity({"row_count": 5, "valid_igsn_count": 4})
     assert result.passed  # 4/5 = 80%
 
 
 def test_igsn_validity_rate_warns_below_threshold():
-    ctx = build_asset_context()
-    pdv_log = {"dataframe": pd.DataFrame({"valid_igsn": ["A", None, None, None, None]})}
-    result = igsn_validity_rate(ctx, pdv_log=pdv_log)
+    result = eval_igsn_validity({"row_count": 5, "valid_igsn_count": 1})
     assert not result.passed  # 1/5 = 20%
     assert result.severity.value == "WARN"
 
 
+def test_igsn_validity_rate_empty_passes():
+    result = eval_igsn_validity({"row_count": 0, "valid_igsn_count": 0})
+    assert result.passed
+
+
 def test_pdv_match_rate_passes():
-    ctx = build_asset_context()
-    pdv_data = {"rows_with_pdv": 2, "matched_count": 2}
-    result = pdv_match_rate(ctx, pdv_data=pdv_data)
+    result = eval_pdv_match_rate({"rows_with_pdv": 2, "matched_count": 2})
     assert result.passed  # 2/2 = 100%
 
 
 def test_pdv_match_rate_warns():
-    ctx = build_asset_context()
-    pdv_data = {"rows_with_pdv": 4, "matched_count": 1}
-    result = pdv_match_rate(ctx, pdv_data=pdv_data)
+    result = eval_pdv_match_rate({"rows_with_pdv": 4, "matched_count": 1})
     assert not result.passed  # 1/4 = 25%
 
 
 def test_igsn_consistency_passes():
-    ctx = build_asset_context()
-    result = igsn_consistency(ctx, pdv_data={"pdv_issues": []})
+    result = eval_igsn_consistency({"igsn_mismatch_count": 0})
     assert result.passed
 
 
 def test_igsn_consistency_errors_on_mismatch():
-    ctx = build_asset_context()
-    pdv_data = {
-        "pdv_issues": [
-            {"type": "igsn_mismatch", "spreadsheet_igsn": "A", "item_igsn": "B"},
-        ],
-    }
-    result = igsn_consistency(ctx, pdv_data=pdv_data)
+    result = eval_igsn_consistency({"igsn_mismatch_count": 1})
     assert not result.passed
     assert result.severity.value == "ERROR"
 
 
 def test_enrichment_success_rate_passes():
-    ctx = build_asset_context()
-    pdv_data = {"written_count": 9, "matched_count": 10, "write_errors": []}
-    result = enrichment_success_rate(ctx, pdv_data=pdv_data)
+    result = eval_enrichment_success_rate(
+        {"items_enriched": 9, "items_simulated": 0, "matched_count": 10}
+    )
     assert result.passed  # 9/10 = 90%
 
 
 def test_enrichment_success_rate_warns():
-    ctx = build_asset_context()
-    pdv_data = {"written_count": 5, "matched_count": 10, "write_errors": [{}] * 5}
-    result = enrichment_success_rate(ctx, pdv_data=pdv_data)
+    result = eval_enrichment_success_rate(
+        {"items_enriched": 5, "items_simulated": 0, "matched_count": 10,
+         "write_errors_count": 5}
+    )
     assert not result.passed  # 5/10 = 50%
 
 
 def test_enrichment_success_rate_counts_dry_run_simulated():
-    """A dry run (written=0, simulated=matched) reads as a representative pass."""
-    ctx = build_asset_context()
-    pdv_data = {
-        "written_count": 0,
-        "simulated_count": 10,
-        "matched_count": 10,
-        "write_errors": [],
-    }
-    result = enrichment_success_rate(ctx, pdv_data=pdv_data)
+    """A dry run (enriched=0, simulated=matched) reads as a representative pass."""
+    result = eval_enrichment_success_rate(
+        {"items_enriched": 0, "items_simulated": 10, "matched_count": 10}
+    )
     assert result.passed  # (0+10)/10 = 100%
 
 
 def test_coord_transform_check_all_ok():
-    ctx = build_asset_context()
-    pdv_data = {
-        "coord_failures": 0,
-        "version_counter": {"HELIX/v2": 3},
-        "yaml_sha256": "abc" * 21 + "a",
-        "written_count": 3,
-    }
-    result = coord_transform_check(ctx, pdv_data=pdv_data)
+    result = eval_coord_transform({
+        "coordinate_transform_failures": 0,
+        "transform_version_count": 1,
+        "yaml_sha256_present": True,
+        "items_enriched": 3,
+        "items_simulated": 0,
+    })
     assert result.passed is True
 
 
 def test_coord_transform_check_failures():
-    ctx = build_asset_context()
-    pdv_data = {
-        "coord_failures": 2,
-        "version_counter": {"HELIX/v2": 1},
-        "yaml_sha256": "abc" * 21 + "a",
-        "written_count": 3,
-    }
-    result = coord_transform_check(ctx, pdv_data=pdv_data)
+    result = eval_coord_transform({
+        "coordinate_transform_failures": 2,
+        "transform_version_count": 1,
+        "yaml_sha256_present": True,
+        "items_enriched": 3,
+        "items_simulated": 0,
+    })
     assert result.passed is False
     assert "2" in result.description
 
 
 def test_coord_transform_check_no_version_resolved():
-    ctx = build_asset_context()
-    pdv_data = {
-        "coord_failures": 0,
-        "version_counter": {},
-        "yaml_sha256": "abc" * 21 + "a",
-        "written_count": 3,
-    }
-    result = coord_transform_check(ctx, pdv_data=pdv_data)
+    result = eval_coord_transform({
+        "coordinate_transform_failures": 0,
+        "transform_version_count": 0,
+        "yaml_sha256_present": True,
+        "items_enriched": 3,
+        "items_simulated": 0,
+    })
     assert result.passed is False
 
 
+def test_coord_transform_check_no_version_ok_when_nothing_attempted():
+    """Empty partition (no writes attempted) shouldn't fail on missing versions."""
+    result = eval_coord_transform({
+        "coordinate_transform_failures": 0,
+        "transform_version_count": 0,
+        "yaml_sha256_present": True,
+        "items_enriched": 0,
+        "items_simulated": 0,
+    })
+    assert result.passed is True
+
+
 def test_coord_transform_check_missing_sha():
-    ctx = build_asset_context()
-    pdv_data = {
-        "coord_failures": 0,
-        "version_counter": {"HELIX/v2": 3},
-        "yaml_sha256": None,
-        "written_count": 3,
-    }
-    result = coord_transform_check(ctx, pdv_data=pdv_data)
+    result = eval_coord_transform({
+        "coordinate_transform_failures": 0,
+        "transform_version_count": 1,
+        "yaml_sha256_present": False,
+        "items_enriched": 3,
+        "items_simulated": 0,
+    })
     assert result.passed is False
     assert "sha" in result.description.lower()
 
 
 def test_manifest_written_passes():
-    ctx = build_asset_context()
-    manifest = {"manifest_written": True, "status": "completed_clean"}
-    result = manifest_written(ctx, pdv_processing_manifest=manifest)
+    result = eval_manifest_written({"manifest_written": True, "status": "completed_clean"})
     assert result.passed
     assert result.severity.value == "ERROR"
 
 
 def test_manifest_written_fails():
-    ctx = build_asset_context()
-    manifest = {"manifest_written": False, "status": "completed_clean"}
-    result = manifest_written(ctx, pdv_processing_manifest=manifest)
+    result = eval_manifest_written({"manifest_written": False, "status": "completed_clean"})
     assert not result.passed
     assert result.severity.value == "ERROR"

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -1,4 +1,8 @@
-"""Tests for Dagster asset checks."""
+"""Tests for the retargeted helix_spreadsheet asset checks.
+
+Each check now reads a single asset's bundled output dict (pdv_log,
+pdv_data, or pdv_processing_manifest).
+"""
 
 import pandas as pd
 from dagster import build_asset_context
@@ -8,152 +12,147 @@ from aimdl_coord_enrichment.checks import (
     enrichment_success_rate,
     igsn_consistency,
     igsn_validity_rate,
+    manifest_written,
     pdv_match_rate,
-    zero_inventory,
+    zero_pdv_inventory,
 )
 
 
-def test_zero_inventory_fails_on_empty():
+def test_zero_pdv_inventory_fails_on_empty():
     ctx = build_asset_context()
-    result = zero_inventory(ctx, pdv_trace_inventory=[])
+    result = zero_pdv_inventory(ctx, pdv_data={"inventory_count": 0})
     assert not result.passed
     assert result.severity.value == "ERROR"
 
 
-def test_zero_inventory_passes_with_items():
+def test_zero_pdv_inventory_passes_with_items():
     ctx = build_asset_context()
-    result = zero_inventory(ctx, pdv_trace_inventory=[{"_id": "a"}])
+    result = zero_pdv_inventory(ctx, pdv_data={"inventory_count": 5})
     assert result.passed
 
 
 def test_igsn_validity_rate_passes_above_threshold():
     ctx = build_asset_context()
-    validated = {
-        "dataframe": pd.DataFrame({"valid_igsn": ["A", "B", "C", "D", None]}),
-        "igsn_issues": [],
-    }
-    result = igsn_validity_rate(ctx, validated_rows=validated)
+    pdv_log = {"dataframe": pd.DataFrame({"valid_igsn": ["A", "B", "C", "D", None]})}
+    result = igsn_validity_rate(ctx, pdv_log=pdv_log)
     assert result.passed  # 4/5 = 80%
 
 
 def test_igsn_validity_rate_warns_below_threshold():
     ctx = build_asset_context()
-    validated = {
-        "dataframe": pd.DataFrame({"valid_igsn": ["A", None, None, None, None]}),
-        "igsn_issues": [],
-    }
-    result = igsn_validity_rate(ctx, validated_rows=validated)
+    pdv_log = {"dataframe": pd.DataFrame({"valid_igsn": ["A", None, None, None, None]})}
+    result = igsn_validity_rate(ctx, pdv_log=pdv_log)
     assert not result.passed  # 1/5 = 20%
     assert result.severity.value == "WARN"
 
 
 def test_pdv_match_rate_passes():
     ctx = build_asset_context()
-    validated = {
-        "dataframe": pd.DataFrame({"PDV_FileName": ["shot1", "shot2"]}),
-        "igsn_issues": [],
-    }
-    xrefs = {"matches": {0: {}, 1: {}}, "pdv_issues": []}
-    result = pdv_match_rate(ctx, pdv_cross_references=xrefs, validated_rows=validated)
+    pdv_data = {"rows_with_pdv": 2, "matched_count": 2}
+    result = pdv_match_rate(ctx, pdv_data=pdv_data)
     assert result.passed  # 2/2 = 100%
 
 
 def test_pdv_match_rate_warns():
     ctx = build_asset_context()
-    validated = {
-        "dataframe": pd.DataFrame({"PDV_FileName": ["shot1", "shot2", "shot3", "shot4"]}),
-        "igsn_issues": [],
-    }
-    xrefs = {"matches": {0: {}}, "pdv_issues": []}
-    result = pdv_match_rate(ctx, pdv_cross_references=xrefs, validated_rows=validated)
+    pdv_data = {"rows_with_pdv": 4, "matched_count": 1}
+    result = pdv_match_rate(ctx, pdv_data=pdv_data)
     assert not result.passed  # 1/4 = 25%
 
 
 def test_igsn_consistency_passes():
     ctx = build_asset_context()
-    xrefs = {"matches": {}, "pdv_issues": []}
-    result = igsn_consistency(ctx, pdv_cross_references=xrefs)
+    result = igsn_consistency(ctx, pdv_data={"pdv_issues": []})
     assert result.passed
 
 
 def test_igsn_consistency_errors_on_mismatch():
     ctx = build_asset_context()
-    xrefs = {
-        "matches": {},
+    pdv_data = {
         "pdv_issues": [
             {"type": "igsn_mismatch", "spreadsheet_igsn": "A", "item_igsn": "B"},
         ],
     }
-    result = igsn_consistency(ctx, pdv_cross_references=xrefs)
+    result = igsn_consistency(ctx, pdv_data=pdv_data)
     assert not result.passed
     assert result.severity.value == "ERROR"
 
 
 def test_enrichment_success_rate_passes():
     ctx = build_asset_context()
-    enriched = {"written_count": 9, "write_errors": [], "coord_failures": 0}
-    xrefs = {"matches": {i: {} for i in range(10)}, "pdv_issues": []}
-    result = enrichment_success_rate(
-        ctx, enriched_pdv_metadata=enriched, pdv_cross_references=xrefs
-    )
+    pdv_data = {"written_count": 9, "matched_count": 10, "write_errors": []}
+    result = enrichment_success_rate(ctx, pdv_data=pdv_data)
     assert result.passed  # 9/10 = 90%
 
 
 def test_enrichment_success_rate_warns():
     ctx = build_asset_context()
-    enriched = {"written_count": 5, "write_errors": [{}] * 5, "coord_failures": 0}
-    xrefs = {"matches": {i: {} for i in range(10)}, "pdv_issues": []}
-    result = enrichment_success_rate(
-        ctx, enriched_pdv_metadata=enriched, pdv_cross_references=xrefs
-    )
+    pdv_data = {"written_count": 5, "matched_count": 10, "write_errors": [{}] * 5}
+    result = enrichment_success_rate(ctx, pdv_data=pdv_data)
     assert not result.passed  # 5/10 = 50%
 
 
 def test_coord_transform_check_all_ok():
     ctx = build_asset_context()
-    enriched = {
+    pdv_data = {
         "coord_failures": 0,
         "version_counter": {"HELIX/v2": 3},
         "yaml_sha256": "abc" * 21 + "a",
         "written_count": 3,
     }
-    result = coord_transform_check(ctx, enriched_pdv_metadata=enriched)
+    result = coord_transform_check(ctx, pdv_data=pdv_data)
     assert result.passed is True
 
 
 def test_coord_transform_check_failures():
     ctx = build_asset_context()
-    enriched = {
+    pdv_data = {
         "coord_failures": 2,
         "version_counter": {"HELIX/v2": 1},
         "yaml_sha256": "abc" * 21 + "a",
         "written_count": 3,
     }
-    result = coord_transform_check(ctx, enriched_pdv_metadata=enriched)
+    result = coord_transform_check(ctx, pdv_data=pdv_data)
     assert result.passed is False
     assert "2" in result.description
 
 
 def test_coord_transform_check_no_version_resolved():
     ctx = build_asset_context()
-    enriched = {
+    pdv_data = {
         "coord_failures": 0,
         "version_counter": {},
         "yaml_sha256": "abc" * 21 + "a",
         "written_count": 3,
     }
-    result = coord_transform_check(ctx, enriched_pdv_metadata=enriched)
+    result = coord_transform_check(ctx, pdv_data=pdv_data)
     assert result.passed is False
 
 
 def test_coord_transform_check_missing_sha():
     ctx = build_asset_context()
-    enriched = {
+    pdv_data = {
         "coord_failures": 0,
         "version_counter": {"HELIX/v2": 3},
         "yaml_sha256": None,
         "written_count": 3,
     }
-    result = coord_transform_check(ctx, enriched_pdv_metadata=enriched)
+    result = coord_transform_check(ctx, pdv_data=pdv_data)
     assert result.passed is False
     assert "sha" in result.description.lower()
+
+
+def test_manifest_written_passes():
+    ctx = build_asset_context()
+    manifest = {"manifest_written": True, "status": "completed_clean"}
+    result = manifest_written(ctx, pdv_processing_manifest=manifest)
+    assert result.passed
+    assert result.severity.value == "ERROR"
+
+
+def test_manifest_written_fails():
+    ctx = build_asset_context()
+    manifest = {"manifest_written": False, "status": "completed_clean"}
+    result = manifest_written(ctx, pdv_processing_manifest=manifest)
+    assert not result.passed
+    assert result.severity.value == "ERROR"

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -92,6 +92,19 @@ def test_enrichment_success_rate_warns():
     assert not result.passed  # 5/10 = 50%
 
 
+def test_enrichment_success_rate_counts_dry_run_simulated():
+    """A dry run (written=0, simulated=matched) reads as a representative pass."""
+    ctx = build_asset_context()
+    pdv_data = {
+        "written_count": 0,
+        "simulated_count": 10,
+        "matched_count": 10,
+        "write_errors": [],
+    }
+    result = enrichment_success_rate(ctx, pdv_data=pdv_data)
+    assert result.passed  # (0+10)/10 = 100%
+
+
 def test_coord_transform_check_all_ok():
     ctx = build_asset_context()
     pdv_data = {

--- a/tests/test_helix_check_partition_isolation.py
+++ b/tests/test_helix_check_partition_isolation.py
@@ -1,0 +1,134 @@
+"""Regression: helix_spreadsheet asset checks must not force an IOManager
+load across the partition cross-product.
+
+Defect (found 2026-06-15 during the issue-31 dry run): the pdv_log /
+pdv_data / pdv_processing_manifest checks took their partitioned asset as
+a positional input, so running the partitioned job for ONE partition made
+Dagster's IOManager load the asset for *other* partitions ->
+FileNotFoundError -> all 7 checks errored, even though the three assets
+materialized cleanly. Same defect family as the coord_enrichment leaf
+checks (see test_leaf_check_partition_isolation.py and
+coord_enrichment/check_support.py).
+
+This runs the real partitioned job for one partition while a second
+dynamic partition is registered but never materialized. With the defect
+present the run fails on the check steps; with the fix the run succeeds
+and all seven checks evaluate.
+"""
+
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+from dagster import DagsterInstance, materialize
+
+from aimdl_coord_enrichment.assets import (
+    pdv_data,
+    pdv_log,
+    pdv_processing_manifest,
+)
+from aimdl_coord_enrichment.checks import (
+    coord_transform_check,
+    enrichment_success_rate,
+    igsn_consistency,
+    igsn_validity_rate,
+    manifest_written,
+    pdv_match_rate,
+    zero_pdv_inventory,
+)
+from aimdl_coord_enrichment.coordinates import _COORD_TRANSFORMER
+
+requires_transformer = pytest.mark.skipif(
+    _COORD_TRANSFORMER is None,
+    reason="coordinate-transformer not configured",
+)
+
+MATERIALIZED_KEY = "JHAMAL00018-005//2026-04-16"
+# A second dynamic partition registered but never materialized. Under the
+# defect, the checks' IOManager load reaches for this one.
+SIBLING_KEY = "JHAMAL00018-007//2026-04-15"
+
+
+def _log_df():
+    """Raw (pre-COLUMN_MAP) experiment-log rows for the materialized key."""
+    return pd.DataFrame([
+        {
+            "Timestamp": "2026-04-16T17:00:00+00:00",
+            "Sample_ID": "JHAMAL00018-005",
+            "PDV_FileName": "shot001",
+            "Flyer_Row": 1,
+            "Flyer_Column": 2,
+            "Flyer_X_Position_Corrected (mm)": 8.0,
+            "Flyer_Y_Position_Corrected (mm)": 8.0,
+        },
+    ])
+
+
+def _pdv_inventory():
+    return [
+        {"name": "shot001_ch1.tdms", "_id": "pdv1",
+         "meta": {"igsn": "JHAMAL00018-005", "data_type": "pdv_trace"}},
+    ]
+
+
+@requires_transformer
+def test_partition_job_succeeds_with_unmaterialized_sibling_partition():
+    from unittest.mock import MagicMock
+
+    with DagsterInstance.ephemeral() as instance:
+        instance.add_dynamic_partitions(
+            "helix_experiment_log", [MATERIALIZED_KEY, SIBLING_KEY]
+        )
+        girder = MagicMock()
+
+        with patch(
+            "aimdl_coord_enrichment.assets.fetch_partition_details",
+            side_effect=lambda g, dt, key: [{"_id": "log1", "name": "log.csv"}],
+        ), patch(
+            "aimdl_coord_enrichment.assets.download_and_read",
+            side_effect=lambda g, item_id, name: _log_df(),
+        ), patch(
+            "aimdl_coord_enrichment.assets.fetch_all_aimdl_datafiles",
+            side_effect=lambda g, dt: _pdv_inventory(),
+        ):
+            result = materialize(
+                [
+                    pdv_log,
+                    pdv_data,
+                    pdv_processing_manifest,
+                    igsn_validity_rate,
+                    zero_pdv_inventory,
+                    pdv_match_rate,
+                    igsn_consistency,
+                    enrichment_success_rate,
+                    coord_transform_check,
+                    manifest_written,
+                ],
+                instance=instance,
+                resources={"girder": girder},
+                partition_key=MATERIALIZED_KEY,
+                run_config={
+                    "ops": {
+                        "pdv_data": {"config": {"dry_run": True}},
+                        "pdv_processing_manifest": {"config": {"dry_run": True}},
+                    }
+                },
+            )
+
+    assert result.success, "partitioned job run must succeed end-to-end"
+
+    # In dry run nothing is written to Girder.
+    girder.addMetadataToItem.assert_not_called()
+
+    check_evals = {
+        e.check_name: e.passed for e in result.get_asset_check_evaluations()
+    }
+    assert check_evals == {
+        "igsn_validity_rate": True,
+        "zero_pdv_inventory": True,
+        "pdv_match_rate": True,
+        "igsn_consistency": True,
+        "enrichment_success_rate": True,
+        "coord_transform_check": True,
+        "manifest_written": True,
+    }, check_evals

--- a/tests/test_helix_spreadsheet_helpers.py
+++ b/tests/test_helix_spreadsheet_helpers.py
@@ -173,6 +173,24 @@ def test_write_processing_manifest_write_failure():
     assert manifest["write_failed"] is True
 
 
+def test_write_processing_manifest_dry_run_skips_write():
+    girder = MagicMock()
+    summary = {
+        "status": "completed_clean",
+        "issues_summary": {},
+        "total_rows": 1,
+        "rows_valid_igsn": 1,
+        "rows_matched_pdv": 1,
+        "rows_enriched": 1,
+    }
+    manifest = write_processing_manifest(
+        girder, "item123", summary, run_id="run1", dry_run=True
+    )
+    girder.addMetadataToItem.assert_not_called()
+    assert "write_failed" not in manifest
+    assert manifest["status"] == "completed_clean"
+
+
 def test_write_pdv_metadata_writes_coords_and_provenance():
     if _COORD_TRANSFORMER is None:
         pytest.skip("CoordinateTransformer unavailable (YAML missing)")
@@ -268,3 +286,34 @@ def test_write_pdv_metadata_records_write_errors():
     assert summary["written_count"] == 0
     assert len(summary["write_errors"]) == 1
     assert summary["write_errors"][0]["row"] == 0
+
+
+def test_write_pdv_metadata_dry_run_skips_writes():
+    if _COORD_TRANSFORMER is None:
+        pytest.skip("CoordinateTransformer unavailable (YAML missing)")
+
+    df = pd.DataFrame([
+        {
+            "Timestamp": datetime(2026, 4, 1, 12, 0, 0, tzinfo=timezone.utc),
+            "valid_igsn": "ABCDEF12345",
+            "PDV_FileName": "shot001",
+            "Flyer_X_Position_Final_mm": 10.5,
+            "Flyer_Y_Position_Final_mm": 20.3,
+        },
+    ])
+    matches = {0: {"_id": "pdvitem1", "name": "shot001_ch1.tdms", "meta": {}}}
+    girder = MagicMock()
+    summary = write_pdv_metadata(
+        girder, df, matches,
+        run_id="run1",
+        source_item_id="src",
+        yaml_sha256="deadbeef",
+        transformer_version="0.0.0-test",
+        dry_run=True,
+    )
+    girder.addMetadataToItem.assert_not_called()
+    assert summary["written_count"] == 0
+    assert summary["simulated_count"] == 1
+    assert summary["write_errors"] == []
+    # Transform still computed in a dry run.
+    assert summary["version_counter"]

--- a/tests/test_helix_spreadsheet_helpers.py
+++ b/tests/test_helix_spreadsheet_helpers.py
@@ -1,0 +1,270 @@
+"""Unit tests for the pure helpers in aimdl_coord_enrichment.spreadsheet.
+
+These replace the coverage the old test_validated_rows_pure /
+test_pdv_cross_references_pure asset tests gave, now that the in-memory
+stages are context-free functions rather than assets.
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from aimdl_coord_enrichment.coordinates import _COORD_TRANSFORMER
+from aimdl_coord_enrichment.spreadsheet import (
+    count_rows_with_pdv,
+    match_pdv_rows,
+    normalize_experiment_log,
+    summarize_pdv_processing,
+    validate_log_rows,
+    write_pdv_metadata,
+    write_processing_manifest,
+)
+
+
+def test_normalize_experiment_log_renames_columns():
+    df = pd.DataFrame([
+        {"Sample_ID": "ABCDEF12345", "Flyer_X_Position_Corrected (mm)": 10.5},
+    ])
+    out = normalize_experiment_log(df)
+    assert "Sample_IGSN" in out.columns
+    assert "Flyer_X_Position_Final_mm" in out.columns
+    assert "Sample_ID" not in out.columns
+
+
+def test_validate_log_rows():
+    df = pd.DataFrame([
+        {"Sample_IGSN": "ABCDEF12345"},
+        {"Sample_IGSN": "INVALID"},
+        {"Sample_IGSN": float("nan")},
+        {"Sample_IGSN": "XYZABC67890-sub1"},
+    ])
+    out_df, issues = validate_log_rows(df)
+
+    assert out_df.loc[0, "valid_igsn"] == "ABCDEF12345"
+    assert pd.isna(out_df.loc[1, "valid_igsn"])
+    assert pd.isna(out_df.loc[2, "valid_igsn"])
+    assert out_df.loc[3, "valid_igsn"] == "XYZABC67890-sub1"
+
+    assert len(issues) == 2
+    issue_types = {i["issue"] for i in issues}
+    assert issue_types == {"invalid_format", "missing"}
+
+
+def test_match_pdv_rows_match_and_not_found_and_nan():
+    df = pd.DataFrame([
+        {"PDV_FileName": "shot001", "valid_igsn": "ABCDEF12345"},
+        {"PDV_FileName": "shot999", "valid_igsn": "ABCDEF12346"},
+        {"PDV_FileName": float("nan"), "valid_igsn": "ABCDEF12347"},
+    ])
+    pdv_items = [
+        {"name": "shot001_ch1.tdms", "_id": "a1",
+         "meta": {"igsn": "ABCDEF12345", "data_type": "pdv_trace"}},
+        {"name": "shot002_ch1.tdms", "_id": "b1",
+         "meta": {"igsn": "ABCDEF12346", "data_type": "pdv_trace"}},
+    ]
+    matches, issues = match_pdv_rows(df, pdv_items)
+
+    assert matches[0]["_id"] == "a1"
+    assert 1 not in matches
+    assert 2 not in matches
+    assert len(issues) == 1
+    assert issues[0]["type"] == "not_found"
+    assert issues[0]["row"] == 1
+
+
+def test_match_pdv_rows_flags_igsn_mismatch():
+    df = pd.DataFrame([
+        {"PDV_FileName": "shot001", "valid_igsn": "ABCDEF12345"},
+    ])
+    pdv_items = [
+        {"name": "shot001_ch1.tdms", "_id": "a1",
+         "meta": {"igsn": "XXXXXX99999", "data_type": "pdv_trace"}},
+    ]
+    matches, issues = match_pdv_rows(df, pdv_items)
+    assert 0 in matches
+    mismatches = [i for i in issues if i["type"] == "igsn_mismatch"]
+    assert len(mismatches) == 1
+    assert mismatches[0]["spreadsheet_igsn"] == "ABCDEF12345"
+    assert mismatches[0]["item_igsn"] == "XXXXXX99999"
+
+
+def test_count_rows_with_pdv():
+    df = pd.DataFrame([
+        {"PDV_FileName": "shot001"},
+        {"PDV_FileName": ""},
+        {"PDV_FileName": float("nan")},
+        {"PDV_FileName": "shot004"},
+    ])
+    assert count_rows_with_pdv(df) == 2
+
+
+def test_summarize_pdv_processing_clean():
+    df = pd.DataFrame([{"valid_igsn": "ABCDEF12345"}])
+    pdv_log = {"dataframe": df, "igsn_issues": []}
+    pdv_data = {
+        "pdv_issues": [],
+        "write_errors": [],
+        "matched_count": 1,
+        "written_count": 1,
+        "coord_failures": 0,
+    }
+    summary = summarize_pdv_processing(pdv_log, pdv_data)
+    assert summary["status"] == "completed_clean"
+    assert summary["has_issues"] is False
+    assert summary["total_rows"] == 1
+    assert summary["rows_valid_igsn"] == 1
+    assert summary["rows_enriched"] == 1
+    assert all(v == 0 for v in summary["issues_summary"].values())
+
+
+def test_summarize_pdv_processing_with_warnings():
+    df = pd.DataFrame([{"valid_igsn": None}])
+    pdv_log = {
+        "dataframe": df,
+        "igsn_issues": [{"issue": "invalid_format", "row": 0}],
+    }
+    pdv_data = {
+        "pdv_issues": [{"type": "not_found", "row": 0}],
+        "write_errors": [],
+        "matched_count": 0,
+        "written_count": 0,
+        "coord_failures": 0,
+    }
+    summary = summarize_pdv_processing(pdv_log, pdv_data)
+    assert summary["status"] == "completed_with_warnings"
+    assert summary["issues_summary"]["igsn_invalid"] == 1
+    assert summary["issues_summary"]["pdv_not_found"] == 1
+
+
+def test_write_processing_manifest_success():
+    girder = MagicMock()
+    summary = {
+        "status": "completed_clean",
+        "issues_summary": {"igsn_invalid": 0},
+        "total_rows": 1,
+        "rows_valid_igsn": 1,
+        "rows_matched_pdv": 1,
+        "rows_enriched": 1,
+    }
+    manifest = write_processing_manifest(girder, "item123", summary, run_id="run1")
+    assert manifest["status"] == "completed_clean"
+    assert manifest["dagster_run_id"] == "run1"
+    assert "write_failed" not in manifest
+    girder.addMetadataToItem.assert_called_once()
+    item_id_arg, payload = girder.addMetadataToItem.call_args[0]
+    assert item_id_arg == "item123"
+    assert "processing_status" in payload
+
+
+def test_write_processing_manifest_write_failure():
+    girder = MagicMock()
+    girder.addMetadataToItem.side_effect = RuntimeError("boom")
+    summary = {
+        "status": "completed_clean",
+        "issues_summary": {},
+        "total_rows": 0,
+        "rows_valid_igsn": 0,
+        "rows_matched_pdv": 0,
+        "rows_enriched": 0,
+    }
+    manifest = write_processing_manifest(girder, "item123", summary, run_id="run1")
+    assert manifest["write_failed"] is True
+
+
+def test_write_pdv_metadata_writes_coords_and_provenance():
+    if _COORD_TRANSFORMER is None:
+        pytest.skip("CoordinateTransformer unavailable (YAML missing)")
+
+    df = pd.DataFrame([
+        {
+            "Timestamp": datetime(2026, 4, 1, 12, 0, 0, tzinfo=timezone.utc),
+            "valid_igsn": "ABCDEF12345",
+            "PDV_FileName": "shot001",
+            "Flyer_Row": 1,
+            "Flyer_Column": 2,
+            "Flyer_X_Position_Final_mm": 10.5,
+            "Flyer_Y_Position_Final_mm": 20.3,
+        },
+    ])
+    matches = {
+        0: {"_id": "pdvitem1", "name": "shot001_ch1.tdms",
+            "meta": {"igsn": "ABCDEF12345"}},
+    }
+    girder = MagicMock()
+    summary = write_pdv_metadata(
+        girder, df, matches,
+        run_id="run1",
+        source_item_id="src_sheet",
+        yaml_sha256="deadbeef",
+        transformer_version="0.0.0-test",
+    )
+
+    assert summary["written_count"] == 1
+    assert summary["write_errors"] == []
+    assert summary["version_counter"]
+    girder.addMetadataToItem.assert_called_once()
+    item_id_arg, payload = girder.addMetadataToItem.call_args[0]
+    assert item_id_arg == "pdvitem1"
+    assert "Station_X" in payload
+    assert "Sample_X" in payload
+    prov = payload["coord_provenance"]
+    assert prov["instrument"] == "HELIX"
+    assert prov["station_coord_source"]["spreadsheet_item_id"] == "src_sheet"
+    assert prov["station_coord_source"]["spreadsheet_row_index"] == 0
+
+
+def test_write_pdv_metadata_per_row_source_item_id():
+    if _COORD_TRANSFORMER is None:
+        pytest.skip("CoordinateTransformer unavailable (YAML missing)")
+
+    df = pd.DataFrame([
+        {
+            "Timestamp": datetime(2026, 4, 1, 12, 0, 0, tzinfo=timezone.utc),
+            "valid_igsn": "ABCDEF12345",
+            "PDV_FileName": "shot001",
+            "Flyer_X_Position_Final_mm": 10.5,
+            "Flyer_Y_Position_Final_mm": 20.3,
+            "_source_item_id": "log_item_B",
+        },
+    ])
+    matches = {0: {"_id": "pdvitem1", "name": "shot001_ch1.tdms", "meta": {}}}
+    girder = MagicMock()
+    write_pdv_metadata(
+        girder, df, matches,
+        run_id="run1",
+        source_item_id="log_item_A_fallback",
+        yaml_sha256="deadbeef",
+        transformer_version="0.0.0-test",
+    )
+    _, payload = girder.addMetadataToItem.call_args[0]
+    assert payload["coord_provenance"]["station_coord_source"]["spreadsheet_item_id"] == "log_item_B"
+
+
+def test_write_pdv_metadata_records_write_errors():
+    if _COORD_TRANSFORMER is None:
+        pytest.skip("CoordinateTransformer unavailable (YAML missing)")
+
+    df = pd.DataFrame([
+        {
+            "Timestamp": datetime(2026, 4, 1, 12, 0, 0, tzinfo=timezone.utc),
+            "valid_igsn": "ABCDEF12345",
+            "PDV_FileName": "shot001",
+            "Flyer_X_Position_Final_mm": 10.5,
+            "Flyer_Y_Position_Final_mm": 20.3,
+        },
+    ])
+    matches = {0: {"_id": "pdvitem1", "name": "shot001_ch1.tdms", "meta": {}}}
+    girder = MagicMock()
+    girder.addMetadataToItem.side_effect = RuntimeError("girder down")
+    summary = write_pdv_metadata(
+        girder, df, matches,
+        run_id="run1",
+        source_item_id="src",
+        yaml_sha256="deadbeef",
+        transformer_version="0.0.0-test",
+    )
+    assert summary["written_count"] == 0
+    assert len(summary["write_errors"]) == 1
+    assert summary["write_errors"][0]["row"] == 0

--- a/tests/test_sensors_helix_discovery.py
+++ b/tests/test_sensors_helix_discovery.py
@@ -1,0 +1,65 @@
+"""Tests for helix_experiment_log_discovery_sensor — partition add
+requests and partitioned RunRequest construction with content-hash run keys."""
+
+from unittest.mock import MagicMock
+
+from dagster import (
+    DagsterInstance,
+    SensorResult,
+    build_sensor_context,
+)
+
+from aimdl_coord_enrichment.sensors import helix_experiment_log_discovery_sensor
+
+
+def _mock_girder_with(index: dict[str, str]) -> MagicMock:
+    """MagicMock client whose .get('aimdl/partition', parameters=...) returns
+    the experiment-log index, simulating fetch_partition_index's HTTP shape."""
+    client = MagicMock()
+
+    def fake_get(path, parameters=None):
+        if path == "aimdl/partition":
+            assert parameters["dataType"] == "pdv_experiment_log"
+            return index
+        raise AssertionError(f"unexpected client call: {path} {parameters}")
+
+    client.get.side_effect = fake_get
+    return client
+
+
+def _run_sensor(girder):
+    ctx = build_sensor_context(
+        instance=DagsterInstance.ephemeral(),
+        resources={"girder": girder},
+    )
+    return helix_experiment_log_discovery_sensor(ctx)
+
+
+def test_sensor_empty_index_emits_no_requests():
+    result = _run_sensor(_mock_girder_with({}))
+    assert isinstance(result, SensorResult)
+    assert result.run_requests == []
+    assert len(result.dynamic_partitions_requests) == 1
+    assert result.dynamic_partitions_requests[0].partition_keys == []
+
+
+def test_sensor_adds_sorted_partitions_and_one_request_per_key():
+    index = {"K2//T2": "hashB", "K1//T1": "hashA"}
+    result = _run_sensor(_mock_girder_with(index))
+
+    adds = result.dynamic_partitions_requests[0].partition_keys
+    assert adds == ["K1//T1", "K2//T2"]  # sorted union
+
+    assert len(result.run_requests) == 2
+    by_pk = {rr.partition_key: rr for rr in result.run_requests}
+    assert set(by_pk) == {"K1//T1", "K2//T2"}
+
+
+def test_sensor_run_key_embeds_content_hash():
+    index = {"K1//T1": "hashA"}
+    result = _run_sensor(_mock_girder_with(index))
+    rr = result.run_requests[0]
+    assert rr.run_key == "helix-pdv-log|K1//T1|hash=hashA"
+    assert rr.partition_key == "K1//T1"
+    assert rr.tags["data_type"] == "pdv_experiment_log"
+    assert rr.tags["content_hash"] == "hashA"


### PR DESCRIPTION
Closes #31.

## What this does

Collapses the over-granular 9-asset `helix_spreadsheet` flow into **3 durable, partitioned assets**, keyed on the AIMD-L dynamic partition `"<igsn>//<experiment_date>"`:

```
pdv_log → pdv_data → pdv_processing_manifest
```

- `pdv_log` — resolve + read + normalize + validate the experiment log (replaces `experiment_log_source`, `raw_experiment_log`, `validated_rows`).
- `pdv_data` — PDV inventory match, IGSN consistency, coordinate transform, write enriched coord/provenance metadata to matched `pdv_trace` items (replaces `pdv_trace_inventory`, `pdv_cross_references`, `enriched_pdv_metadata`).
- `pdv_processing_manifest` — aggregate + write `meta.processing_status` to the source log item (replaces `quality_report`, `processing_manifest`).

In-memory transforms moved to pure, unit-tested helpers in `spreadsheet.py`. The 6 original checks are retargeted onto the 3 assets and read **event-log metadata** via `latest_partition_metadata()` (never take the partitioned asset as input — avoids the IOManager cross-product load), plus a new `manifest_written` ERROR check. A new `helix_experiment_log_discovery_sensor` emits partitioned RunRequests (deduped by content hash).

Safe by default: `dry_run=True` on the writing assets, discovery sensor ships STOPPED.

## Verification

- `pytest tests/ -v` → **341 passed, 1 skipped** (Python 3.12).
- High-effort code review of `main...` diff: no correctness/crash bugs found.

## Known non-blocking follow-ups (surfaced by review)

Advisory checks only (they do not block execution); all on edge-case partitions:

- `enrichment_success_rate` and `coord_transform_check` emit a spurious WARN for a partition whose rows have no PDV matches / no coordinates (rate `0/0`).
- `manifest_written` reports a false ERROR when a partition transiently resolves zero log items.
- The flow has no automated live-write path yet — sensor RunRequests omit `run_config` so they run `dry_run=True`; live writes require a manual launch with config override (intentional opt-in).
- ALPSS completeness reporting was dropped from this flow (per the issue, to be handled in the observer flow); note the observer currently measures a different metric.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
